### PR TITLE
Release 2.1.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+## 2.1.0 2018-06-06
+ * MODNOTES-31 "readonly" fields like creatorUserName, etc should be ignorable
+ * MODNOTES-34 Update the 'domain-models-runtime' dependency version
+ * MODNOTES-37 GET /notes/_self requires unexpected permission
+ * MODNOTES-15 Query validation
+ * MODNOTES-39 Fix invalid UUIDs
+ * general tightening of error responses, using RMB's helpers where possible
+ * Code cleanup
+
 ## 2.0.1 2017-11-14
  * MODNOTES-24 Upgrade to RMB 15
  * Requires interface 'users' in 14.0 or 15.0

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio.rest</groupId>
   <artifactId>mod-notes</artifactId>
-  <version>2.1.0</version>
+  <version>2.1.1-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <licenses>
@@ -50,7 +50,7 @@
     <url>https://github.com/folio-org/mod-notes</url>
     <connection>scm:git:git://github.com/folio-org/mod-notes</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-notes.git</developerConnection>
-    <tag>v2.1.0</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio.rest</groupId>
   <artifactId>mod-notes</artifactId>
-  <version>2.0.2-SNAPSHOT</version>
+  <version>2.1.0</version>
   <packaging>jar</packaging>
 
   <licenses>
@@ -50,7 +50,7 @@
     <url>https://github.com/folio-org/mod-notes</url>
     <connection>scm:git:git://github.com/folio-org/mod-notes</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-notes.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>v2.1.0</tag>
   </scm>
 
   <dependencies>


### PR DESCRIPTION
 * MODNOTES-31 "readonly" fields like creatorUserName, etc should be ignorable
 * MODNOTES-34 Update the 'domain-models-runtime' dependency version
 * MODNOTES-37 GET /notes/_self requires unexpected permission
 * MODNOTES-15 Query validation
 * MODNOTES-39 Fix invalid UUIDs
 * general tightening of error responses, using RMB's helpers where possible
 * Code cleanup