### PR TITLE
MODNOTES-62 Update note type

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -55,16 +55,25 @@
         {
           "methods": ["GET"],
           "pathPattern": "/note-types"
-        }, {
-          "methods": ["POST"],
-          "pathPattern": "/note-types"
-        }, {
+        },
+        {
           "methods": ["GET"],
           "pathPattern": "/note-types/{typeId}",
           "permissionsRequired": ["note.types.item.get"]
+        },
+        {
+          "methods": ["POST"],
+          "pathPattern": "/note-types",
+          "permissionsRequired": ["note.types.item.post"]
+        },
+        {
+          "methods": ["PUT"],
+          "pathPattern": "/note-types/{id}",
+          "permissionsRequired": ["note.types.item.put"]
         }
       ]
-    }, {
+    },
+    {
       "id": "_jsonSchemas",
       "version": "1.0",
       "interfaceType" : "multiple",
@@ -136,6 +145,16 @@
       "description": "All domains"
     },
     {
+      "permissionName": "note.types.item.post",
+      "displayName": "Note types - create note type",
+      "description": "Create note type"
+    },
+    {
+      "permissionName": "note.types.item.put",
+      "displayName": "Note types - modify note type",
+      "description": "Modify note type"
+    },
+    {
       "permissionName": "notes.allops",
       "displayName": "Notes module - all CRUD permissions",
       "description": "Entire set of permissions needed to use the notes modules, but no domain permissions",
@@ -158,7 +177,9 @@
       "displayName": "Note types - all CRUD permissions",
       "description": "Entire set of permissions needed to use the note type for note module",
       "subPermissions": [
-        "note.types.item.get"
+        "note.types.item.get",
+        "note.types.item.post",
+        "note.types.item.put"
       ],
       "visible": false
     },

--- a/src/main/java/org/folio/rest/impl/NoteTypesImpl.java
+++ b/src/main/java/org/folio/rest/impl/NoteTypesImpl.java
@@ -62,9 +62,12 @@ public class NoteTypesImpl implements NoteTypes {
   }
 
   @Override
-  public void putNoteTypesByTypeId(String typeId, String lang, NoteType entity, Map<String, String> okapiHeaders,
-                                   Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+  public void putNoteTypesByTypeId(String typeId, String lang, NoteType entity, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    removeNotStoredFields(entity);
+    PgUtil.put(NOTE_TYPE_TABLE, entity, typeId, okapiHeaders, vertxContext, PutNoteTypesByTypeIdResponse.class, asyncResultHandler);
+  }
 
-    asyncResultHandler.handle(Future.succeededFuture(PutNoteTypesByTypeIdResponse.status(Response.Status.NOT_IMPLEMENTED).build()));
+  private void removeNotStoredFields(NoteType entity) {
+    entity.setUsage(null);
   }
 }

--- a/src/test/java/org/folio/rest/TestBase.java
+++ b/src/test/java/org/folio/rest/TestBase.java
@@ -3,6 +3,8 @@ package org.folio.rest;
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
 
+import org.apache.http.HttpHeaders;
+import org.apache.http.entity.ContentType;
 import org.folio.okapi.common.XOkapiHeaders;
 import org.folio.rest.client.TenantClient;
 import org.folio.rest.impl.NoteTypesImplTest;
@@ -18,6 +20,7 @@ import com.github.tomakehurst.wiremock.junit.WireMockRule;
 
 import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.filter.log.LogDetail;
+import io.restassured.http.Header;
 import io.restassured.specification.RequestSpecification;
 import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Vertx;
@@ -28,6 +31,7 @@ import io.vertx.core.logging.LoggerFactory;
 public class TestBase {
 
   public static final String STUB_TENANT = "testlib";
+  protected static final Header JSON_CONTENT_TYPE_HEADER = new Header(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_JSON.getMimeType());
   private static final Logger logger = LoggerFactory.getLogger(NoteTypesImplTest.class);
   private static final String STUB_TOKEN = "TEST_OKAPI_TOKEN";
   private static final String host = "http://127.0.0.1";

--- a/src/test/java/org/folio/rest/impl/NoteTypesImplTest.java
+++ b/src/test/java/org/folio/rest/impl/NoteTypesImplTest.java
@@ -3,47 +3,63 @@ package org.folio.rest.impl;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static org.folio.rest.impl.TestUtil.readFile;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.List;
+
+import org.apache.http.HttpStatus;
+import org.apache.http.protocol.HTTP;
+import org.folio.rest.TestBase;
+import org.folio.rest.jaxrs.model.NoteType;
+import org.folio.rest.jaxrs.model.NoteTypeUsage;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
 import com.github.tomakehurst.wiremock.matching.EqualToPattern;
 import com.github.tomakehurst.wiremock.matching.UrlPathPattern;
-import io.restassured.http.Header;
-import io.vertx.ext.unit.junit.VertxUnitRunner;
-import java.io.IOException;
-import java.net.URISyntaxException;
-
-import org.apache.http.protocol.HTTP;
-import org.folio.rest.TestBase;
-import org.junit.Test;
 
 import io.restassured.RestAssured;
-import org.junit.runner.RunWith;
+import io.restassured.http.Header;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
 
 @RunWith(VertxUnitRunner.class)
 public class NoteTypesImplTest extends TestBase {
 
-  private final String NOT_EXISTING_STUB_ID = "9798274e-ce9d-46ab-aa28-00ca9cf4698a";
-  private final String NOTE_TYPES_ENDPOINT = "/note-types";
-  private final Header CONTENT_TYPE_HEADER = new Header(HTTP.CONTENT_TYPE, "application/json");
+  private static final int NOTE_TOTAL = 10;
+  private static final String STUB_NOTE_TYPE_ID = "2cf21797-d25b-46dc-8427-1759d1db2057";
+  private static final String NOT_EXISTING_STUB_ID = "9798274e-ce9d-46ab-aa28-00ca9cf4698a";
+  private static final String NOTE_TYPES_ENDPOINT = "/note-types";
+  private static final Header CONTENT_TYPE_HEADER = new Header(HTTP.CONTENT_TYPE, "application/json");
+
+  private ObjectMapper mapper = new ObjectMapper();
 
   @Test
-  public void shouldReturn200WithNoteTypeWhenValidId () throws IOException, URISyntaxException {
+  public void shouldReturn200WithNoteTypeWhenValidId() throws IOException, URISyntaxException {
+    try {
+      final String stubNoteType = readFile("post_note_type.json");
+      final String stubId = "9c1e6f3c-682d-4af4-bd6b-20dad912ff94";
 
-    final String stubNoteType = readFile("post_note_type.json");
-    final String stubId = "9c1e6f3c-682d-4af4-bd6b-20dad912ff94";
+      NoteTypesTestUtil.insertNoteType(vertx, stubId, stubNoteType);
 
-    NoteTypesTestUtil.insertNoteType(vertx, stubId, stubNoteType);
-
-    RestAssured.given()
-      .spec(getRequestSpecification())
-      .when()
-      .get(NOTE_TYPES_ENDPOINT + "/" + stubId)
-      .then()
-      .statusCode(200).extract().asString();
+      RestAssured.given()
+        .spec(getRequestSpecification())
+        .when()
+        .get(NOTE_TYPES_ENDPOINT + "/" + stubId)
+        .then()
+        .statusCode(200).extract().asString();
+    } finally {
+      NoteTypesTestUtil.deleteAllNoteTypes(vertx);
+    }
   }
 
   @Test
-  public void shouldReturn404WhenInvalidId (){
+  public void shouldReturn404WhenInvalidId() {
 
     RestAssured.given()
       .spec(getRequestSpecification())
@@ -54,11 +70,11 @@ public class NoteTypesImplTest extends TestBase {
   }
 
   @Test
-  public void shouldReturn500WhenErrorOccurred (){
+  public void shouldReturn500WhenErrorOccurred() {
 
     final String invalidStubId = "11111111-222-1111-2-111111111111";
     stubFor(
-      get(new UrlPathPattern(new EqualToPattern(NOTE_TYPES_ENDPOINT +"/" + invalidStubId), false))
+      get(new UrlPathPattern(new EqualToPattern(NOTE_TYPES_ENDPOINT + "/" + invalidStubId), false))
         .willReturn(new ResponseDefinitionBuilder()
           .withStatus(500)));
 
@@ -71,7 +87,7 @@ public class NoteTypesImplTest extends TestBase {
   }
 
   @Test
-  public void shouldReturn501WhenDeleteEndpointNotImplemented (){
+  public void shouldReturn501WhenDeleteEndpointNotImplemented() {
 
     stubFor(
       get(new UrlPathPattern(new EqualToPattern(NOTE_TYPES_ENDPOINT + "/" + NOT_EXISTING_STUB_ID), false))
@@ -87,7 +103,7 @@ public class NoteTypesImplTest extends TestBase {
   }
 
   @Test
-  public void shouldReturn501WhenPostEndpointNotImplemented () throws IOException, URISyntaxException {
+  public void shouldReturn501WhenPostEndpointNotImplemented() throws IOException, URISyntaxException {
 
     stubFor(
       get(new UrlPathPattern(new EqualToPattern(NOTE_TYPES_ENDPOINT), false))
@@ -105,21 +121,68 @@ public class NoteTypesImplTest extends TestBase {
   }
 
   @Test
-  public void shouldReturn501WhenPutEndpointNotImplemented () throws IOException, URISyntaxException {
+  public void shouldUpdateNoteNameTypeOnPut() throws IOException, URISyntaxException {
+    try {
+      NoteTypesTestUtil.insertNoteType(vertx, STUB_NOTE_TYPE_ID, TestUtil.readFile("post_note.json"));
+      NoteType updatedNoteType = mapper.readValue(TestUtil.readFile("put_note.json"), NoteType.class);
+      updateNoteType(updatedNoteType);
 
-    stubFor(
-      get(new UrlPathPattern(new EqualToPattern(NOTE_TYPES_ENDPOINT+ "/" + NOT_EXISTING_STUB_ID), false))
-        .willReturn(new ResponseDefinitionBuilder()
-          .withStatus(501)));
-
-    RestAssured.given()
-      .spec(getRequestSpecification())
-      .header(CONTENT_TYPE_HEADER)
-      .body(readFile("post_note_type.json"))
-      .when()
-      .put(NOTE_TYPES_ENDPOINT + "/" + NOT_EXISTING_STUB_ID)
-      .then()
-      .statusCode(501).extract().asString();
+      List<NoteType> noteTypes = NoteTypesTestUtil.getAllNoteTypes(vertx);
+      assertEquals(1, noteTypes.size());
+      assertEquals(updatedNoteType.getName(), noteTypes.get(0).getName());
+    } finally {
+      NoteTypesTestUtil.deleteAllNoteTypes(vertx);
+    }
   }
 
+  @Test
+  public void shouldNotSetNoteUsageOnPut() throws IOException, URISyntaxException {
+    try {
+      NoteTypesTestUtil.insertNoteType(vertx, STUB_NOTE_TYPE_ID, TestUtil.readFile("post_note.json"));
+      NoteType updatedNoteType = mapper.readValue(TestUtil.readFile("put_note.json"), NoteType.class);
+      updatedNoteType.withUsage(new NoteTypeUsage().withNoteTotal(NOTE_TOTAL));
+      updateNoteType(updatedNoteType);
+
+      List<NoteType> noteTypes = NoteTypesTestUtil.getAllNoteTypes(vertx);
+      assertEquals(1, noteTypes.size());
+      assertNull(noteTypes.get(0).getUsage());
+    } finally {
+      NoteTypesTestUtil.deleteAllNoteTypes(vertx);
+    }
+  }
+
+  @Test
+  public void shouldReturn404OnPutWhenNoteNotFound() throws IOException, URISyntaxException {
+    RestAssured.given()
+      .spec(getRequestSpecification())
+      .header(JSON_CONTENT_TYPE_HEADER)
+      .when()
+      .body(TestUtil.readFile("put_note.json"))
+      .put("note-types/" + STUB_NOTE_TYPE_ID)
+      .then()
+      .statusCode(HttpStatus.SC_NOT_FOUND);
+  }
+
+  @Test
+  public void shouldReturn400OnPutWhenRequestIsInvalid() {
+    RestAssured.given()
+      .spec(getRequestSpecification())
+      .header(JSON_CONTENT_TYPE_HEADER)
+      .when()
+      .body("{\"name\":null}")
+      .put("note-types/" + STUB_NOTE_TYPE_ID)
+      .then()
+      .statusCode(HttpStatus.SC_UNPROCESSABLE_ENTITY);
+  }
+
+  private void updateNoteType(NoteType updatedNoteType) throws JsonProcessingException {
+    RestAssured.given()
+      .spec(getRequestSpecification())
+      .header(JSON_CONTENT_TYPE_HEADER)
+      .when()
+      .body(mapper.writeValueAsString(updatedNoteType))
+      .put("note-types/" + STUB_NOTE_TYPE_ID)
+      .then()
+      .statusCode(HttpStatus.SC_NO_CONTENT);
+  }
 }

--- a/src/test/java/org/folio/rest/impl/NoteTypesTestUtil.java
+++ b/src/test/java/org/folio/rest/impl/NoteTypesTestUtil.java
@@ -2,9 +2,15 @@ package org.folio.rest.impl;
 
 import static org.folio.rest.TestBase.STUB_TENANT;
 
+import java.io.IOException;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
 
+import org.folio.rest.jaxrs.model.NoteType;
 import org.folio.rest.persist.PostgresClient;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.vertx.core.Vertx;
 
@@ -28,4 +34,34 @@ class NoteTypesTestUtil {
       return PostgresClient.convertToPsqlStandard(STUB_TENANT) + "." + NOTE_TYPE_TABLE;
     }
 
+
+  public static List<NoteType> getAllNoteTypes(Vertx vertx) {
+    ObjectMapper mapper = new ObjectMapper();
+    CompletableFuture<List<NoteType>> future = new CompletableFuture<>();
+    PostgresClient.getInstance(vertx).select(
+      "SELECT * FROM " + getNoteTypesTableName(),
+      event -> future.complete(event.result().getRows().stream()
+        .map(row -> row.getString(JSONB_COLUMN))
+        .map(json -> parseNoteType(mapper, json))
+        .collect(Collectors.toList())));
+    return future.join();
+  }
+
+  public static void deleteAllNoteTypes(Vertx vertx) {
+    CompletableFuture<Void> future = new CompletableFuture<>();
+    PostgresClient.getInstance(vertx).execute(
+      "DELETE FROM " + getNoteTypesTableName(),
+      event -> future.complete(null));
+    future.join();
+  }
+
+
+  private static NoteType parseNoteType(ObjectMapper mapper, String json) {
+    try {
+      return mapper.readValue(json, NoteType.class);
+    } catch (IOException e) {
+      e.printStackTrace();
+      throw new IllegalArgumentException("Can't parse note type", e);
+    }
+  }
 }

--- a/src/test/resources/post_note.json
+++ b/src/test/resources/post_note.json
@@ -1,0 +1,6 @@
+{
+  "name": "High Priority",
+  "usage": {
+    "noteTotal": 10
+  }
+}

--- a/src/test/resources/put_note.json
+++ b/src/test/resources/put_note.json
@@ -1,0 +1,4 @@
+{
+  "id": "2cf21797-d25b-46dc-8427-1759d1db2057",
+  "name": "Medium Priority"
+}


### PR DESCRIPTION
## Purpose
Implement PUT /notes-types/{id} endpoint
## Approach
* updated ModuleDescriptor
* added implementation for PUT /notes-types/{id} endpoint
* added tests

## Note
- this PR should be merged after https://github.com/folio-org/mod-notes/pull/75