### PR TITLE
MODNOTES-60 - Implement GET type endpoint

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -51,10 +51,20 @@
           "pathPattern": "/notes/{id}",
           "permissionsRequired": ["notes.item.delete"],
           "permissionsDesired": ["notes.domain.*", "notes.domain.all"]
+        },
+        {
+          "methods": ["GET"],
+          "pathPattern": "/note-types"
+        }, {
+          "methods": ["POST"],
+          "pathPattern": "/note-types"
+        }, {
+          "methods": ["GET"],
+          "pathPattern": "/note-types/{typeId}",
+          "permissionsRequired": ["note.types.item.get"]
         }
       ]
-    },
-    {
+    }, {
       "id": "_jsonSchemas",
       "version": "1.0",
       "interfaceType" : "multiple",
@@ -64,8 +74,7 @@
           "pathPattern" : "/_/jsonSchemas"
         }
       ]
-    },
-    {
+    }, {
       "id": "_ramls",
       "version": "1.0",
       "interfaceType" : "multiple",
@@ -75,8 +84,7 @@
           "pathPattern" : "/_/ramls"
         }
       ]
-    },
-    {
+    }, {
       "id": "_tenant",
       "version": "1.0",
       "interfaceType": "system",
@@ -141,12 +149,27 @@
       "visible": false
     },
     {
+      "permissionName": "note.types.item.get",
+      "displayName": "Note types - get individual note type from storage",
+      "description": "Get individual note type"
+    },
+    {
+      "permissionName": "note.types.allops",
+      "displayName": "Note types - all CRUD permissions",
+      "description": "Entire set of permissions needed to use the note type for note module",
+      "subPermissions": [
+        "note.types.item.get"
+      ],
+      "visible": false
+    },
+    {
       "permissionName": "notes.all",
       "displayName": "Notes module - all permissions and all domains",
       "description": "Entire set of permissions needed to use the notes modules on any domain",
       "subPermissions": [
         "notes.allops",
-        "notes.domain.all"
+        "notes.domain.all",
+        "note.types.allops"
       ],
       "visible": false
     }

--- a/pom.xml
+++ b/pom.xml
@@ -111,6 +111,24 @@
       <version>${vertx-version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.rest-assured</groupId>
+      <artifactId>rest-assured</artifactId>
+      <version>3.3.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.github.tomakehurst</groupId>
+      <artifactId>wiremock</artifactId>
+      <version>2.19.0</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>net.sf.jopt-simple</groupId>
+          <artifactId>jopt-simple</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/org/folio/rest/impl/NoteTypesImpl.java
+++ b/src/main/java/org/folio/rest/impl/NoteTypesImpl.java
@@ -1,0 +1,70 @@
+package org.folio.rest.impl;
+
+import java.util.Map;
+
+import java.util.Objects;
+import javax.ws.rs.core.Response;
+
+import org.folio.rest.annotations.Validate;
+import org.folio.rest.jaxrs.model.NoteType;
+import org.folio.rest.jaxrs.model.NoteTypeUsage;
+import org.folio.rest.jaxrs.resource.NoteTypes;
+import org.folio.rest.persist.PgUtil;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+
+public class NoteTypesImpl implements NoteTypes {
+
+  private static final String NOTE_TYPE_TABLE = "note_type";
+
+  @Override
+  public void getNoteTypes(String query, int offset, int limit, String lang, Map<String, String> okapiHeaders,
+                           Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+
+    asyncResultHandler.handle(Future.succeededFuture(GetNoteTypesResponse.status(Response.Status.NOT_IMPLEMENTED).build()));
+  }
+
+  @Override
+  public void postNoteTypes(String lang, NoteType entity, Map<String, String> okapiHeaders,
+                            Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+
+    asyncResultHandler.handle(Future.succeededFuture(PostNoteTypesResponse.status(Response.Status.NOT_IMPLEMENTED).build()));
+  }
+
+  @Validate
+  @Override
+  public void getNoteTypesByTypeId(String typeId, String lang, Map<String, String> okapiHeaders,
+                                   Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+
+    Handler<AsyncResult<Response>> handlerWrapper = event -> {
+      if(event.succeeded() && Response.Status.OK.getStatusCode() == event.result().getStatus()) {
+
+        final NoteType noteType = (NoteType) event.result().getEntity();
+        if (Objects.isNull(noteType.getUsage())) {
+          noteType.setUsage(new NoteTypeUsage().withNoteTotal(0));
+        }
+      }
+      asyncResultHandler.handle(event);
+    };
+
+    PgUtil.getById(NOTE_TYPE_TABLE, NoteType.class, typeId, okapiHeaders, vertxContext, GetNoteTypesByTypeIdResponse.class, handlerWrapper);
+
+  }
+
+  @Override
+  public void deleteNoteTypesByTypeId(String typeId, String lang, Map<String, String> okapiHeaders,
+                                      Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+
+    asyncResultHandler.handle(Future.succeededFuture(DeleteNoteTypesByTypeIdResponse.status(Response.Status.NOT_IMPLEMENTED).build()));
+  }
+
+  @Override
+  public void putNoteTypesByTypeId(String typeId, String lang, NoteType entity, Map<String, String> okapiHeaders,
+                                   Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+
+    asyncResultHandler.handle(Future.succeededFuture(PutNoteTypesByTypeIdResponse.status(Response.Status.NOT_IMPLEMENTED).build()));
+  }
+}

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -17,6 +17,7 @@
     },
     {
       "tableName": "note_type",
+      "pkColumnName": "_id",
       "generateId": true,
       "fromModuleVersion": 1.0,
       "withMetadata": true,

--- a/src/test/java/org/folio/rest/TestBase.java
+++ b/src/test/java/org/folio/rest/TestBase.java
@@ -1,0 +1,115 @@
+package org.folio.rest;
+
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+
+import org.folio.okapi.common.XOkapiHeaders;
+import org.folio.rest.client.TenantClient;
+import org.folio.rest.impl.NoteTypesImplTest;
+import org.folio.rest.persist.PostgresClient;
+import org.folio.rest.tools.utils.NetworkUtils;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+
+import com.github.tomakehurst.wiremock.common.Slf4jNotifier;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+
+import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.filter.log.LogDetail;
+import io.restassured.specification.RequestSpecification;
+import io.vertx.core.DeploymentOptions;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+
+public class TestBase {
+
+  public static final String STUB_TENANT = "testlib";
+  private static final Logger logger = LoggerFactory.getLogger(NoteTypesImplTest.class);
+  private static final String STUB_TOKEN = "TEST_OKAPI_TOKEN";
+  private static final String host = "http://127.0.0.1";
+  private static final String HTTP_PORT = "http.port";
+  private static final int port = NetworkUtils.nextFreePort();
+  protected static Vertx vertx;
+  @Rule
+  public WireMockRule userMockServer = new WireMockRule(
+    WireMockConfiguration.wireMockConfig()
+      .dynamicPort()
+      .notifier(new Slf4jNotifier(true)));
+
+  @BeforeClass
+  public static void setup() throws IOException {
+
+    vertx = Vertx.vertx();
+
+    logger.info("Start embedded database");
+    PostgresClient.setIsEmbedded(true);
+    PostgresClient.getInstance(vertx).startEmbeddedPostgres();
+
+    DeploymentOptions options = new DeploymentOptions().setConfig(new JsonObject().put(HTTP_PORT, port));
+
+    startVerticle(options);
+
+    postTenant(options);
+  }
+
+  private static void startVerticle(DeploymentOptions options) {
+
+    logger.info("Start verticle");
+
+    CompletableFuture<Void> future = new CompletableFuture<>();
+    vertx.deployVerticle(RestVerticle.class.getName(), options, event -> future.complete(null));
+    future.join();
+  }
+
+  private static void postTenant(DeploymentOptions options) {
+
+    logger.info("Post tenant");
+
+    TenantClient tenantClient = new TenantClient(host + ":" + port, STUB_TENANT, STUB_TOKEN);
+
+    CompletableFuture<Void> future = new CompletableFuture<>();
+    vertx.deployVerticle(RestVerticle.class.getName(), options, res -> {
+      try {
+        tenantClient.postTenant(null, res2 -> future.complete(null));
+      } catch (Exception e) {
+        e.printStackTrace();
+      }
+    });
+    future.join();
+  }
+
+  @AfterClass
+  public static void tearDown(){
+
+    logger.info("Stop embedded database");
+
+    CompletableFuture<Void> future = new CompletableFuture<>();
+    vertx.close(res -> {
+      PostgresClient.stopEmbeddedPostgres();
+      future.complete(null);
+    });
+    future.join();
+  }
+
+  protected RequestSpecification getRequestSpecification() {
+    return new RequestSpecBuilder()
+      .addHeader(XOkapiHeaders.TENANT, STUB_TENANT)
+      .addHeader(XOkapiHeaders.TOKEN, STUB_TOKEN)
+      .addHeader(XOkapiHeaders.URL, getWiremockUrl())
+      .setBaseUri(host + ":" + port)
+      .setPort(port)
+      .log(LogDetail.ALL)
+      .build();
+  }
+
+  /**
+   * Returns url of Wiremock server used in this test
+   */
+  private String getWiremockUrl() {
+    return host + ":" + userMockServer.port();
+  }
+}

--- a/src/test/java/org/folio/rest/impl/NoteTypesImplTest.java
+++ b/src/test/java/org/folio/rest/impl/NoteTypesImplTest.java
@@ -1,0 +1,125 @@
+package org.folio.rest.impl;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static org.folio.rest.impl.TestUtil.readFile;
+
+import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
+import com.github.tomakehurst.wiremock.matching.EqualToPattern;
+import com.github.tomakehurst.wiremock.matching.UrlPathPattern;
+import io.restassured.http.Header;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import java.io.IOException;
+import java.net.URISyntaxException;
+
+import org.apache.http.protocol.HTTP;
+import org.folio.rest.TestBase;
+import org.junit.Test;
+
+import io.restassured.RestAssured;
+import org.junit.runner.RunWith;
+
+@RunWith(VertxUnitRunner.class)
+public class NoteTypesImplTest extends TestBase {
+
+  private final String NOT_EXISTING_STUB_ID = "9798274e-ce9d-46ab-aa28-00ca9cf4698a";
+  private final String NOTE_TYPES_ENDPOINT = "/note-types";
+  private final Header CONTENT_TYPE_HEADER = new Header(HTTP.CONTENT_TYPE, "application/json");
+
+  @Test
+  public void shouldReturn200WithNoteTypeWhenValidId () throws IOException, URISyntaxException {
+
+    final String stubNoteType = readFile("post_note_type.json");
+    final String stubId = "9c1e6f3c-682d-4af4-bd6b-20dad912ff94";
+
+    NoteTypesTestUtil.insertNoteType(vertx, stubId, stubNoteType);
+
+    RestAssured.given()
+      .spec(getRequestSpecification())
+      .when()
+      .get(NOTE_TYPES_ENDPOINT + "/" + stubId)
+      .then()
+      .statusCode(200).extract().asString();
+  }
+
+  @Test
+  public void shouldReturn404WhenInvalidId (){
+
+    RestAssured.given()
+      .spec(getRequestSpecification())
+      .when()
+      .get(NOTE_TYPES_ENDPOINT + "/" + NOT_EXISTING_STUB_ID)
+      .then()
+      .statusCode(404).extract().asString();
+  }
+
+  @Test
+  public void shouldReturn500WhenErrorOccurred (){
+
+    final String invalidStubId = "11111111-222-1111-2-111111111111";
+    stubFor(
+      get(new UrlPathPattern(new EqualToPattern(NOTE_TYPES_ENDPOINT +"/" + invalidStubId), false))
+        .willReturn(new ResponseDefinitionBuilder()
+          .withStatus(500)));
+
+    RestAssured.given()
+      .spec(getRequestSpecification())
+      .when()
+      .get(NOTE_TYPES_ENDPOINT + "/" + invalidStubId)
+      .then()
+      .statusCode(500).extract().asString();
+  }
+
+  @Test
+  public void shouldReturn501WhenDeleteEndpointNotImplemented (){
+
+    stubFor(
+      get(new UrlPathPattern(new EqualToPattern(NOTE_TYPES_ENDPOINT + "/" + NOT_EXISTING_STUB_ID), false))
+        .willReturn(new ResponseDefinitionBuilder()
+          .withStatus(501)));
+
+    RestAssured.given()
+      .spec(getRequestSpecification())
+      .when()
+      .delete(NOTE_TYPES_ENDPOINT + "/" + NOT_EXISTING_STUB_ID)
+      .then()
+      .statusCode(501).extract().asString();
+  }
+
+  @Test
+  public void shouldReturn501WhenPostEndpointNotImplemented () throws IOException, URISyntaxException {
+
+    stubFor(
+      get(new UrlPathPattern(new EqualToPattern(NOTE_TYPES_ENDPOINT), false))
+        .willReturn(new ResponseDefinitionBuilder()
+          .withStatus(501)));
+
+    RestAssured.given()
+      .spec(getRequestSpecification())
+      .header(CONTENT_TYPE_HEADER)
+      .body(readFile("post_note_type.json"))
+      .when()
+      .post(NOTE_TYPES_ENDPOINT)
+      .then()
+      .statusCode(501).extract().asString();
+  }
+
+  @Test
+  public void shouldReturn501WhenPutEndpointNotImplemented () throws IOException, URISyntaxException {
+
+    stubFor(
+      get(new UrlPathPattern(new EqualToPattern(NOTE_TYPES_ENDPOINT+ "/" + NOT_EXISTING_STUB_ID), false))
+        .willReturn(new ResponseDefinitionBuilder()
+          .withStatus(501)));
+
+    RestAssured.given()
+      .spec(getRequestSpecification())
+      .header(CONTENT_TYPE_HEADER)
+      .body(readFile("post_note_type.json"))
+      .when()
+      .put(NOTE_TYPES_ENDPOINT + "/" + NOT_EXISTING_STUB_ID)
+      .then()
+      .statusCode(501).extract().asString();
+  }
+
+}

--- a/src/test/java/org/folio/rest/impl/NoteTypesTestUtil.java
+++ b/src/test/java/org/folio/rest/impl/NoteTypesTestUtil.java
@@ -1,0 +1,31 @@
+package org.folio.rest.impl;
+
+import static org.folio.rest.TestBase.STUB_TENANT;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.folio.rest.persist.PostgresClient;
+
+import io.vertx.core.Vertx;
+
+class NoteTypesTestUtil {
+
+  private static final String JSONB_COLUMN = "jsonb";
+  private static final String NOTE_TYPE_TABLE = "note_type";
+
+  private NoteTypesTestUtil() {
+  }
+
+  public static void insertNoteType(Vertx vertx, String stubId, String noteType) {
+    CompletableFuture<Void> future = new CompletableFuture<>();
+    PostgresClient.getInstance(vertx).execute(
+      "INSERT INTO " + getNoteTypesTableName() + "(" + " _id, " + JSONB_COLUMN + ") VALUES ('" + stubId + "' , '" + noteType + "');" ,
+      event -> future.complete(null));
+    future.join();
+  }
+
+    private static String getNoteTypesTableName() {
+      return PostgresClient.convertToPsqlStandard(STUB_TENANT) + "." + NOTE_TYPE_TABLE;
+    }
+
+}

--- a/src/test/java/org/folio/rest/impl/TestUtil.java
+++ b/src/test/java/org/folio/rest/impl/TestUtil.java
@@ -1,0 +1,25 @@
+package org.folio.rest.impl;
+
+import com.google.common.io.Files;
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+
+public class TestUtil {
+
+  /**
+   * Reads file from classpath as String
+   */
+  public static String readFile(String filename) throws IOException, URISyntaxException {
+    return Files.asCharSource(getFile(filename), StandardCharsets.UTF_8).read();
+  }
+
+  /**
+   * Returns File object corresponding to the file on classpath with specified filename
+   */
+  public static File getFile(String filename) throws URISyntaxException {
+    return new File(TestUtil.class.getClassLoader()
+      .getResource(filename).toURI());
+  }
+}

--- a/src/test/resources/post_note_type.json
+++ b/src/test/resources/post_note_type.json
@@ -1,0 +1,4 @@
+{
+  "id": "9c1e6f3c-682d-4af4-bd6b-20dad912ff94",
+  "name": "Low Priority"
+}


### PR DESCRIPTION
## Purpose
Due to https://issues.folio.org/browse/MODNOTES-60 we are expecting to get an individual note type by `/note-type/{typeId}` endpoint

## Approach
* updated ModuleDescriptor with `note-types` interface and related permissions
* updated `schema.json` file to have `_id` column
* added implementation for GET `/note-types/{typeId}` endpoint
* added tests for `/note-types/{typeId}` and also sample tests for other not implemented yet endpoints to pass Sonar quality gate

## Open Questions
[ ] - define  if `permissionsDesired` property needed to be established

## Note
 - functionality for `"usage"` note type property will be added in further stories related to mod-notes 