### PR TITLE
MODNOTES-65 Remove permission logic

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -19,38 +19,32 @@
         {
           "methods": ["GET"],
           "pathPattern": "/notes",
-          "permissionsRequired": ["notes.collection.get"],
-          "permissionsDesired": ["notes.domain.*", "notes.domain.all"]
+          "permissionsRequired": ["notes.collection.get", "notes.domain.all"]
         },
         {
           "methods": ["POST"],
           "pathPattern": "/notes",
-          "permissionsRequired": ["notes.item.post"],
-          "permissionsDesired": ["notes.domain.*", "notes.domain.all"]
+          "permissionsRequired": ["notes.item.post", "notes.domain.all"]
         },
         {
           "methods": ["GET"],
           "pathPattern": "/notes/_self",
-          "permissionsRequired": ["notes.collection.get"],
-          "permissionsDesired": ["notes.domain.*", "notes.domain.all"]
+          "permissionsRequired": ["notes.collection.get", "notes.domain.all"]
         },
         {
           "methods": ["GET"],
           "pathPattern": "/notes/{id}",
-          "permissionsRequired": ["notes.item.get"],
-          "permissionsDesired": ["notes.domain.*", "notes.domain.all"]
+          "permissionsRequired": ["notes.item.get","notes.domain.all"]
         },
         {
           "methods": ["PUT"],
           "pathPattern": "/notes/{id}",
-          "permissionsRequired": ["notes.item.put"],
-          "permissionsDesired": ["notes.domain.*", "notes.domain.all"]
+          "permissionsRequired": ["notes.item.put", "notes.domain.all"]
         },
         {
           "methods": ["DELETE"],
           "pathPattern": "/notes/{id}",
-          "permissionsRequired": ["notes.item.delete"],
-          "permissionsDesired": ["notes.domain.*", "notes.domain.all"]
+          "permissionsRequired": ["notes.item.delete", "notes.domain.all"]
         },
         {
           "methods": ["GET"],

--- a/pom.xml
+++ b/pom.xml
@@ -96,24 +96,6 @@
       <type>jar</type>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock</artifactId>
-      <version>2.19.0</version>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>net.sf.jopt-simple</groupId>
-          <artifactId>jopt-simple</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.skyscreamer</groupId>
-      <artifactId>jsonassert</artifactId>
-      <version>1.5.0</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-core</artifactId>
       <version>${vertx-version}</version>

--- a/src/test/java/org/folio/rest/impl/NoteTypesTestUtil.java
+++ b/src/test/java/org/folio/rest/impl/NoteTypesTestUtil.java
@@ -22,10 +22,10 @@ class NoteTypesTestUtil {
   private NoteTypesTestUtil() {
   }
 
-  public static void insertNoteType(Vertx vertx, String stubId, String noteType) {
+  public static void insertNoteType(Vertx vertx, String stubId, String json) {
     CompletableFuture<Void> future = new CompletableFuture<>();
     PostgresClient.getInstance(vertx).execute(
-      "INSERT INTO " + getNoteTypesTableName() + "(" + " _id, " + JSONB_COLUMN + ") VALUES ('" + stubId + "' , '" + noteType + "');" ,
+      "INSERT INTO " + getNoteTypesTableName() + "(" + " _id, " + JSONB_COLUMN + ") VALUES ('" + stubId + "' , '" + json + "');" ,
       event -> future.complete(null));
     future.join();
   }


### PR DESCRIPTION
## Purpose
Refactor permission logic

## Approach
Replace permission logic with permissionRequired declaration in ModuleDescriptor, 
All endpoints return 401 exception if notes.domain.all is missing, so it makes sense to make this permission required and remove checks for this permission from code.

#### TODOS and Open Questions
- [x] This PR depends on following PR: https://github.com/folio-org/mod-notes/pull/76