### PR TITLE
MODNOTES-69: Add raml definition for bulk note link update

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -70,6 +70,11 @@
           "methods": ["DELETE"],
           "pathPattern": "/note-types/{id}",
           "permissionsRequired": ["note.types.item.delete"]
+        },
+        {
+          "methods": ["PUT"],
+          "pathPattern": "/note-links/domain/{domain}/type/{type}/id/{id}/",
+          "permissionsRequired": ["note.links.collection.put"]
         }
       ]
     },
@@ -165,6 +170,11 @@
       "description": "Delete note type"
     },
     {
+      "permissionName": "note.links.collection.put",
+      "displayName": "Note links - update note links",
+      "description": "Update note links"
+    },
+    {
       "permissionName": "notes.allops",
       "displayName": "Notes module - all CRUD permissions",
       "description": "Entire set of permissions needed to use the notes modules, but no domain permissions",
@@ -173,7 +183,8 @@
         "notes.item.get",
         "notes.item.post",
         "notes.item.put",
-        "notes.item.delete"
+        "notes.item.delete",
+        "note.links.collection.put"
       ],
       "visible": false
     },

--- a/ramls/examples/link/noteLinksPut.json
+++ b/ramls/examples/link/noteLinksPut.json
@@ -1,0 +1,12 @@
+{
+  "notes" : [
+    {
+      "id" : "62d00c36-a94f-434d-9cd2-c7ea159303da",
+      "status" : "ASSIGNED"
+    },
+    {
+      "id" : "12300c36-a94f-434d-9cd2-c7ea159303da",
+      "status" : "UNASSIGNED"
+    }
+  ]
+}

--- a/ramls/link.raml
+++ b/ramls/link.raml
@@ -1,0 +1,48 @@
+#%RAML 1.0
+title: Note Links
+version: v1.0.0
+baseUri: http://github.com/org/folio/mod-notes
+
+documentation:
+  - title: mod-notes Links API
+    content: This documents the API calls that can be made to query and manage note links of the system
+
+types:
+  noteLinksPut: !include types/link/noteLinksPut.json
+  errors: !include raml-util/schemas/errors.schema
+
+traits:
+  validate: !include raml-util/traits/validation.raml
+  language: !include raml-util/traits/language.raml
+
+/note-links:
+  /domain/{domain}/type/{type}/id/{id}/:
+    put:
+        is: [validate]
+        description: Add links to specified list of notes
+        body:
+          application/json:
+            type: noteLinksPut
+            example:
+              strict: false
+              value: !include examples/link/noteLinksPut.json
+        responses:
+          204:
+            description: "Links successfully added"
+          404:
+            description: "One of the notes from request is not found"
+            body:
+              text/plain:
+                example: |
+                  "Note with id '62d00c36-a94f-434d-9cd2-c7ea159303da' not found"
+          400:
+            description: "Bad request, e.g. malformed request body. Details of the error (e.g. name of the parameter or line/character number with malformed data) provided in the response."
+            body:
+              text/plain:
+                example: |
+                  "unable to update note links -- malformed JSON at 13:4"
+          500:
+            description: "Internal server error"
+            body:
+              text/plain:
+                example: "internal server error, contact administrator"

--- a/ramls/types/link/noteLinkPut.json
+++ b/ramls/types/link/noteLinkPut.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Note Link Schema",
+  "description": "A note link",
+  "javaType": "org.folio.rest.jaxrs.model.NoteLinkPut",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "id": {
+      "description": "A UUID identifying a note",
+      "type": "string"
+    },
+    "status": {
+      "description": "New status for link to this note",
+      "type": "string",
+      "enum": [ "ASSIGNED", "UNASSIGNED" ],
+      "example": "ASSIGNED"
+    }
+  },
+  "required": [
+    "id",
+    "status"
+  ]
+}

--- a/ramls/types/link/noteLinksPut.json
+++ b/ramls/types/link/noteLinksPut.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Collection of note links",
+  "javaType": "org.folio.rest.jaxrs.model.NoteLinksPut",
+  "additionalProperties": false,
+  "properties": {
+    "notes": {
+      "description": "List of note links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "$ref": "noteLinkPut.json"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Jira: MODNOTES-69
Add endpoint that allows updating certain note links for an entity,
by sending list of note ids with status "ASSIGNED/UNASSIGNED",
If status is ASSIGNED, entity will be added as a link to certain note,
If status is UNASSIGNED, entity will be removed from list of links of a note

## Purpose
Add raml changes for https://issues.folio.org/browse/MODNOTES-69

## Approach
Use second approach from https://issues.folio.org/browse/MODNOTES-69 - 
"(2) PUT request which accepts a list of notes and status"
Pass entity information through url path: /note-links/domain/{domain}/type/{type}/id/{id}

#### TODOS and Open Questions
- [ ] I chose second approach from https://issues.folio.org/browse/MODNOTES-69,
 because for first approach UI needs to know list of all previously assigned links for an entity (for example if user searches for all unassigned links and decides to assign some of them, UI will first have to send an additional request to get all assigned links),
and for third approach UI needs to send two separate http requests.
