### PR TITLE
MODNOTES-89 & MODNOTES-90: Make notes specific to a domain

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -73,7 +73,7 @@
         },
         {
           "methods": ["PUT"],
-          "pathPattern": "/note-links/domain/{domain}/type/{type}/id/{id}",
+          "pathPattern": "/note-links/type/{type}/id/{id}",
           "permissionsRequired": ["note.links.collection.put"]
         }
       ]

--- a/ramls/examples/note.sample
+++ b/ramls/examples/note.sample
@@ -2,6 +2,7 @@
   "id": "62d00c36-a94f-434d-9cd2-c7ea159303da",
   "type": "High Priority",
   "title" : "BU Campus Access Issues",
+  "domain": "eholdings",
   "content": "There have been access issues at the BU campus since the weekend",
   "creator": {
     "lastName" : "Smith",
@@ -25,13 +26,11 @@
   "links": [
     {
       "id" : "583-2356521",
-      "type": "package",
-      "domain": "eholdings"
+      "type": "package"
     },
     {
       "id" : "583-2356521-758038",
-      "type": "resource",
-      "domain": "eholdings"
+      "type": "resource"
     }
   ]
 }

--- a/ramls/examples/noteCollection.sample
+++ b/ramls/examples/noteCollection.sample
@@ -4,6 +4,7 @@
        "id": "62d00c36-a94f-434d-9cd2-c7ea159303da",
        "type": "High Priority",
        "title" : "BU Campus Access Issues",
+       "domain": "eholdings",
        "creator": {
          "lastName" : "Smith",
          "firstName": "Robin",
@@ -26,13 +27,11 @@
        "links": [
          {
            "id" : "583-2356521",
-           "type": "package",
-           "domain": "eholdings"
+           "type": "package"
          },
          {
            "id" : "583-2356521-758038",
-           "type": "resource",
-           "domain": "eholdings"
+           "type": "resource"
          }
        ]
      }

--- a/ramls/link.raml
+++ b/ramls/link.raml
@@ -16,7 +16,7 @@ traits:
   language: !include raml-util/traits/language.raml
 
 /note-links:
-  /domain/{domain}/type/{type}/id/{id}/:
+  /type/{type}/id/{id}/:
     put:
         is: [validate]
         description: Add links to specified list of notes

--- a/ramls/types/notes/link.json
+++ b/ramls/types/notes/link.json
@@ -13,16 +13,10 @@
       "type": "string",
       "description": "Type of object linked to note",
       "example": "package"
-    },
-    "domain": {
-      "type": "string",
-      "description": "Domain associated with object linked to note",
-      "example": "eholdings"
     }
   },
   "required": [
     "id",
-    "type",
-    "domain"
+    "type"
   ]
 }

--- a/ramls/types/notes/note.json
+++ b/ramls/types/notes/note.json
@@ -20,6 +20,11 @@
       "example": "Access issues",
       "readonly": true
     },
+    "domain": {
+      "type": "string",
+      "description": "Domain associated with this note",
+      "example": "eholdings"
+    },
     "title": {
       "type": "string",
       "description": "Note title",
@@ -65,6 +70,8 @@
   },
   "required": [
     "typeId",
-    "title"
+    "title",
+    "domain",
+    "links"
   ]
 }

--- a/src/main/java/org/folio/db/model/NoteView.java
+++ b/src/main/java/org/folio/db/model/NoteView.java
@@ -25,6 +25,9 @@ public class NoteView {
   private String typeId;
 
   private String type;
+  
+  @NotNull
+  private String domain;
 
   @NotNull
   private String title;
@@ -51,7 +54,11 @@ public class NoteView {
   public String getType() {
     return type;
   }
-
+  
+  public String getDomain() {
+    return domain;
+  }
+  
   public String getTitle() {
     return title;
   }
@@ -86,6 +93,10 @@ public class NoteView {
 
   public void setType(String type) {
     this.type = type;
+  }
+  
+  public void setDomain(String domain) {
+    this.domain = domain;
   }
 
   public void setTitle(String title) {

--- a/src/main/java/org/folio/rest/impl/NoteLinksImpl.java
+++ b/src/main/java/org/folio/rest/impl/NoteLinksImpl.java
@@ -57,9 +57,9 @@ public class NoteLinksImpl implements NoteLinks {
     "jsonb->'links' = '[]'::jsonb";
 
   @Override
-  public void putNoteLinksDomainTypeIdByDomainAndTypeAndId(String domain, String type, String id,
-                                                           NoteLinksPut entity, Map<String, String> okapiHeaders,
-                                                           Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+  public void putNoteLinksTypeIdByTypeAndId(String type, String id,
+                                               NoteLinksPut entity, Map<String, String> okapiHeaders,
+                                               Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     String tenantId = TenantTool.calculateTenantId(okapiHeaders.get(RestVerticle.OKAPI_HEADER_TENANT));
 
     PostgresClient postgresClient = PostgresClient.getInstance(vertxContext.owner(), tenantId);
@@ -67,7 +67,6 @@ public class NoteLinksImpl implements NoteLinks {
     List<String> assignNotes = getNoteIdsByStatus(entity, NoteLinkPut.Status.ASSIGNED);
     List<String> unAssignNotes = getNoteIdsByStatus(entity, NoteLinkPut.Status.UNASSIGNED);
     Link link = new Link()
-      .withDomain(domain)
       .withId(id)
       .withType(type);
 
@@ -80,12 +79,12 @@ public class NoteLinksImpl implements NoteLinks {
       .compose(o -> unAssignFromNotes(unAssignNotes, link, postgresClient, connection.getValue(), tenantId))
       .compose(result -> endTransaction(postgresClient, connection.getValue()))
       .compose(result -> {
-        asyncResultHandler.handle(succeededFuture(PutNoteLinksDomainTypeIdByDomainAndTypeAndIdResponse.respond204()));
+        asyncResultHandler.handle(succeededFuture(PutNoteLinksTypeIdByTypeAndIdResponse.respond204()));
         return null;
       })
       .otherwise(e -> rollbackTransaction(postgresClient, connection, e))
       .otherwise(e -> {
-        asyncResultHandler.handle(succeededFuture(PutNoteLinksDomainTypeIdByDomainAndTypeAndIdResponse.respond500WithTextPlain(e.getMessage())));
+        asyncResultHandler.handle(succeededFuture(PutNoteLinksTypeIdByTypeAndIdResponse.respond500WithTextPlain(e.getMessage())));
         return null;
       });
   }

--- a/src/main/java/org/folio/rest/impl/NotesResourceImpl.java
+++ b/src/main/java/org/folio/rest/impl/NotesResourceImpl.java
@@ -137,6 +137,7 @@ public class NotesResourceImpl implements Notes {
       .withId(noteView.getId())
       .withTypeId(noteView.getTypeId())
       .withType(noteView.getType())
+      .withDomain(noteView.getDomain())
       .withTitle(noteView.getTitle())
       .withContent(noteView.getContent())
       .withCreator(noteView.getCreator())

--- a/src/main/resources/templates/db_scripts/create_note_view.sql
+++ b/src/main/resources/templates/db_scripts/create_note_view.sql
@@ -5,12 +5,11 @@ CREATE OR REPLACE VIEW note_view AS
   jsonb_build_object(
     'id', note_data.jsonb->>'id',
     'title', note_data.jsonb->>'title',
+    'domain', note_data.jsonb->>'domain',
     'content', note_data.jsonb->>'content',
     'creator', note_data.jsonb->'creator',
     'updater', note_data.jsonb->'updater',
     'links', note_data.jsonb->'links',
-    'linkDomains',
-    (SELECT array_agg(DISTINCT domain) FROM jsonb_to_recordset(note_data.jsonb->'links') AS x(domain text)),
     'linkTypes',
     (SELECT array_agg(DISTINCT type) FROM jsonb_to_recordset(note_data.jsonb->'links') AS x(type text)),
     'linkIds',

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -43,7 +43,7 @@
     },
     {
       "run": "after",
-      "snippet": "CREATE OR REPLACE VIEW note_view AS SELECT note_data.id, jsonb_build_object( 'id', note_data.jsonb->>'id',  'title', note_data.jsonb->>'title',  'content', note_data.jsonb->>'content',  'creator', note_data.jsonb->'creator',  'updater', note_data.jsonb->'updater',  'links', note_data.jsonb->'links',  'linkDomains',  (SELECT array_agg(DISTINCT domain) FROM jsonb_to_recordset(note_data.jsonb->'links') AS x(domain text)),  'linkTypes',  (SELECT array_agg(DISTINCT type) FROM jsonb_to_recordset(note_data.jsonb->'links') AS x(type text)),  'linkIds',  (SELECT array_agg(DISTINCT id) FROM jsonb_to_recordset(note_data.jsonb->'links') AS x(id text)), 'metadata', note_data.jsonb->'metadata',  'typeId', note_type.jsonb->'id', 'type', note_type.jsonb->'name') AS jsonb FROM note_data LEFT JOIN note_type ON note_data.jsonb->>'typeId' = note_type.jsonb->>'id';",
+      "snippet": "CREATE OR REPLACE VIEW note_view AS SELECT note_data.id, jsonb_build_object( 'id', note_data.jsonb->>'id',  'title', note_data.jsonb->>'title', 'domain', note_data.jsonb->>'domain', 'content', note_data.jsonb->>'content',  'creator', note_data.jsonb->'creator',  'updater', note_data.jsonb->'updater',  'links', note_data.jsonb->'links',  'linkTypes',  (SELECT array_agg(DISTINCT type) FROM jsonb_to_recordset(note_data.jsonb->'links') AS x(type text)),  'linkIds',  (SELECT array_agg(DISTINCT id) FROM jsonb_to_recordset(note_data.jsonb->'links') AS x(id text)), 'metadata', note_data.jsonb->'metadata',  'typeId', note_type.jsonb->'id', 'type', note_type.jsonb->'name') AS jsonb FROM note_data LEFT JOIN note_type ON note_data.jsonb->>'typeId' = note_type.jsonb->>'id';",
       "fromModuleVersion": "1.0"
     },
     {

--- a/src/test/java/org/folio/rest/impl/NoteLinksImplTest.java
+++ b/src/test/java/org/folio/rest/impl/NoteLinksImplTest.java
@@ -78,13 +78,11 @@ public class NoteLinksImplTest extends TestBase {
     Note secondResultNote = getNoteById(notes, secondNote.getId());
     Note thirdResultNote = getNoteById(notes, thirdNote.getId());
 
-    assertEquals(DOMAIN, firstResultNote.getLinks().get(DEFAULT_LINK_INDEX + 1).getDomain());
     assertEquals(PACKAGE_TYPE, firstResultNote.getLinks().get(DEFAULT_LINK_INDEX + 1).getType());
     assertEquals(PACKAGE_ID, firstResultNote.getLinks().get(DEFAULT_LINK_INDEX + 1).getId());
 
     assertEquals(DEFAULT_LINK_AMOUNT, secondResultNote.getLinks().size());
 
-    assertEquals(DOMAIN, thirdResultNote.getLinks().get(DEFAULT_LINK_INDEX + 1).getDomain());
     assertEquals(PACKAGE_TYPE, thirdResultNote.getLinks().get(DEFAULT_LINK_INDEX + 1).getType());
     assertEquals(PACKAGE_ID, thirdResultNote.getLinks().get(DEFAULT_LINK_INDEX + 1).getId());
   }
@@ -132,7 +130,6 @@ public class NoteLinksImplTest extends TestBase {
     assertEquals(DEFAULT_LINK_AMOUNT, firstResultNote.getLinks().size());
     assertEquals(DEFAULT_LINK_AMOUNT, secondResultNote.getLinks().size());
 
-    assertEquals(DOMAIN, thirdResultNote.getLinks().get(DEFAULT_LINK_INDEX + 1).getDomain());
     assertEquals(PACKAGE_TYPE, thirdResultNote.getLinks().get(DEFAULT_LINK_INDEX + 1).getType());
     assertEquals(PACKAGE_ID, thirdResultNote.getLinks().get(DEFAULT_LINK_INDEX + 1).getId());
   }
@@ -162,7 +159,6 @@ public class NoteLinksImplTest extends TestBase {
   public void shouldRemoveNoteWhenLastLinkIsRemoved() {
     Note note = getNote()
       .withLinks(Collections.singletonList(new Link()
-        .withDomain(DOMAIN)
         .withId(PACKAGE_ID)
         .withType(PACKAGE_TYPE)
     ));
@@ -174,7 +170,7 @@ public class NoteLinksImplTest extends TestBase {
 
   private void putLinks(NoteLinksPut requestBody) {
     putWithOk(
-      "note-links/domain/" + DOMAIN + "/type/" + PACKAGE_TYPE + "/id/" + PACKAGE_ID,
+      "note-links/type/" + PACKAGE_TYPE + "/id/" + PACKAGE_ID,
       Json.encode(requestBody), USER8);
   }
 

--- a/src/test/java/org/folio/rest/impl/NotesTest.java
+++ b/src/test/java/org/folio/rest/impl/NotesTest.java
@@ -230,6 +230,7 @@ public class NotesTest extends TestBase {
     assertThat(note.getMetadata().getCreatedByUserId(), containsString("-9999-"));
     assertEquals(NOTE_TYPE_NAME, note.getType());
     assertEquals(NOTE_TYPE_ID, note.getTypeId());
+    assertEquals(DOMAIN, note.getDomain());
     assertEquals("test note title", note.getTitle());
     assertThat(note.getContent(), containsString("First note"));
     assertEquals("Mockerson", note.getCreator().getLastName());
@@ -239,8 +240,7 @@ public class NotesTest extends TestBase {
 
     assertThat(note.getLinks(), hasItem(allOf(
       hasProperty("id", is(PACKAGE_ID)),
-      hasProperty("type", is(PACKAGE_TYPE)),
-      hasProperty("domain", is(DOMAIN))
+      hasProperty("type", is(PACKAGE_TYPE))
     )));
   }
 
@@ -283,7 +283,7 @@ public class NotesTest extends TestBase {
 
     final Note note = getWithOk("/notes/22222222-2222-2222-a222-222222222222").as(Note.class);
     assertThat(note.getContent(), containsString("things"));
-
+    assertThat(note.getDomain(), equalTo("eholdings"));
     final Metadata noteMetadata = note.getMetadata();
     assertThat(noteMetadata.getCreatedByUserId(), containsString("-8888-"));
     assertThat(noteMetadata.getCreatedByUsername(), equalTo("m8"));
@@ -322,7 +322,7 @@ public class NotesTest extends TestBase {
   @Test
   public void shouldFindNoteByLinkDomain() {
     postNoteWithOk(NOTE_1, USER9);
-    getNoteAndCheckContent("?query=linkDomains=" + DOMAIN, "First note");
+    getNoteAndCheckContent("?query=domain=" + DOMAIN, "First note");
   }
 
   @Test
@@ -460,7 +460,7 @@ public class NotesTest extends TestBase {
     String newNote2 = rawNote2
       .replaceAll("8888", "9999") // createdBy
       .replaceFirst("23456", "34567") // link to the thing
-      .replaceAll("things", "rooms") // new domain (also in link)
+      .replaceAll("things", "rooms") // new domain
       .replaceFirst("\"m8\"", "\"NewCrUsername\""); // readonly field, should not matter
 
     logger.info("About to PUT note: " + newNote2);
@@ -547,7 +547,7 @@ public class NotesTest extends TestBase {
   public void shouldReturn400WhenLimitIsInvalid() {
     getWithStatus("/notes?query=title=testing&limit=-1", SC_BAD_REQUEST);
   }
-
+  
   @Test
   public void shouldDeleteNoteByPathReturnedFromPost() {
     final String location = postNoteWithOk(NOTE_3, USER9).headers().get("Location").getValue();

--- a/src/test/resources/note/note1.json
+++ b/src/test/resources/note/note1.json
@@ -2,16 +2,15 @@
   "id": "11111111-1111-1111-a111-111111111111",
   "typeId": "2af21797-d25b-46dc-8427-1759d1db2057",
   "title": "test note title",
+  "domain": "eholdings",
   "links": [
     {
       "id": "18-2356521",
-      "type": "package",
-      "domain": "eholdings"
+      "type": "package"
     },
     {
       "id": "19-2356521-758038",
-      "type": "resource",
-      "domain": "eholdings"
+      "type": "resource"
     }
   ],
   "content": "First note email@folio.org"

--- a/src/test/resources/note/note2.json
+++ b/src/test/resources/note/note2.json
@@ -2,12 +2,12 @@
   "id": "22222222-2222-2222-a222-222222222222",
   "typeId": "13f21797-d25b-46dc-8427-1759d1db2057",
   "title": "things",
+  "domain": "eholdings",
   "content": "Test on things",
   "links": [
     {
       "id": "123-456789",
-      "type": "package",
-      "domain": "eholdings"
+      "type": "package"
     }
   ]
 }

--- a/src/test/resources/note/note3.json
+++ b/src/test/resources/note/note3.json
@@ -2,11 +2,11 @@
   "typeId": "2af21797-d25b-46dc-8427-1759d1db2057",
   "title": "testing",
   "content": "Note with no id",
+  "domain": "eholdings",
   "links": [
     {
       "id": "123-456789",
-      "type": "package",
-      "domain": "eholdings"
+      "type": "package"
     }
   ]
 }

--- a/src/test/resources/note/note4.json
+++ b/src/test/resources/note/note4.json
@@ -2,12 +2,12 @@
   "id": "33333333-1111-1111-a333-333333333333",
   "typeId": "13f21797-d25b-46dc-8427-1759d1db2057",
   "title": "things",
+  "domain": "eholdings",
   "content": "Test on things",
   "links": [
     {
       "id": "123-456789",
-      "type": "package",
-      "domain": "eholdings"
+      "type": "package"
     }
   ]
 }

--- a/src/test/resources/note/updateNote4Request.json
+++ b/src/test/resources/note/updateNote4Request.json
@@ -2,5 +2,6 @@
   "id": "33333333-1111-1111-a333-333333333333",
   "typeId": "13f21797-d25b-46dc-8427-1759d1db2057",
   "title": "more things",
-  "content": "Test on things"
+  "content": "Test on things",
+  "domain": "eholdings"
 }

--- a/src/test/resources/note/updateNote5RequestWithNonExistingTypeId.json
+++ b/src/test/resources/note/updateNote5RequestWithNonExistingTypeId.json
@@ -2,12 +2,12 @@
   "id": "33333333-1111-1111-a333-333333333333",
   "typeId": "09c5042e-182a-4aad-aab8-a4501d621541",
   "title": "more things",
+  "domain": "eholdings",
   "content": "Test on things",
   "links": [
     {
       "id": "123-456789",
-      "type": "package",
-      "domain": "eholdings"
+      "type": "package"
     }
   ]
 }

--- a/src/test/resources/note/updateNoteRequest.json
+++ b/src/test/resources/note/updateNoteRequest.json
@@ -1,6 +1,7 @@
 {
   "id": "11111111-1111-1111-a111-111111111111",
   "typeId": "2af21797-d25b-46dc-8427-1759d1db2057",
+  "domain": "eholdings",
   "title": "more things",
   "content": "First note with a comment"
 }

--- a/src/test/resources/note/updateNoteRequestWithLinks.json
+++ b/src/test/resources/note/updateNoteRequestWithLinks.json
@@ -1,17 +1,16 @@
 {
   "typeId": "13f21797-d25b-46dc-8427-1759d1db2057",
   "title": "more things",
+  "domain": "eholdings",
   "content": "First note with a comment",
   "links": [
     {
       "id": "123-456789",
-      "type": "package",
-      "domain": "eholdings"
+      "type": "package"
     },
     {
       "id": "123-456789",
-      "type": "resource",
-      "domain": "eholdings"
+      "type": "resource"
     }
   ]
 }

--- a/src/test/resources/note/updateNoteRequestWithNoId.json
+++ b/src/test/resources/note/updateNoteRequestWithNoId.json
@@ -1,5 +1,6 @@
 {
   "typeId": "2af21797-d25b-46dc-8427-1759d1db2057",
   "title": "more things",
+  "domain": "eholdings",
   "content": "First note with a comment"
 }


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/MODNOTES-89 and https://issues.folio.org/browse/MODNOTES-90, we want to refactor implementation of notes and note-links to be domain specific. 

## Approach
- Change ramls and json schemas to move domain from pre-existing links to note level
- Adjust code and tests accordingly
