### PR TITLE
MODNOTES-71  Notes: Limit the number of note types that can be defined in the systemModnotes 71 limit number of note types

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,11 @@
       <version>4.0.3</version>
     </dependency>
     <dependency>
+      <groupId>uk.com.robust-it</groupId>
+      <artifactId>cloning</artifactId>
+      <version>1.9.11</version>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.12</version>

--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,11 @@
       <version>1.0.0</version>
     </dependency>
     <dependency>
+      <groupId>org.folio</groupId>
+      <artifactId>mod-configuration-client</artifactId>
+      <version>4.0.3</version>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.12</version>

--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,11 @@
       <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.folio</groupId>
+      <artifactId>folio-di-support</artifactId>
+      <version>1.0.0</version>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.12</version>

--- a/src/main/java/org/folio/config/Configuration.java
+++ b/src/main/java/org/folio/config/Configuration.java
@@ -1,0 +1,29 @@
+package org.folio.config;
+
+import io.vertx.core.Future;
+
+import org.folio.util.OkapiParams;
+
+public interface Configuration {
+
+  Future<String> getString(String code, OkapiParams params);
+
+  Future<String> getString(String code, String def, OkapiParams params);
+
+  Future<Integer> getInt(String code, OkapiParams params);
+
+  Future<Integer> getInt(String code, int def, OkapiParams params);
+
+  Future<Long> getLong(String code, OkapiParams params);
+
+  Future<Long> getLong(String code, long def, OkapiParams params);
+
+  Future<Double> getDouble(String code, OkapiParams params);
+
+  Future<Double> getDouble(String code, double def, OkapiParams params);
+
+  Future<Boolean> getBoolean(String code, OkapiParams params);
+
+  Future<Boolean> getBoolean(String code, boolean def, OkapiParams params);
+
+}

--- a/src/main/java/org/folio/config/ConfigurationException.java
+++ b/src/main/java/org/folio/config/ConfigurationException.java
@@ -1,0 +1,16 @@
+package org.folio.config;
+
+public class ConfigurationException extends RuntimeException {
+
+  public ConfigurationException(String message) {
+    super(message);
+  }
+
+  public ConfigurationException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public ConfigurationException(Throwable cause) {
+    super(cause);
+  }
+}

--- a/src/main/java/org/folio/config/ModConfiguration.java
+++ b/src/main/java/org/folio/config/ModConfiguration.java
@@ -1,0 +1,165 @@
+package org.folio.config;
+
+import static java.lang.String.format;
+import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
+
+import static org.folio.util.FutureUtils.wrapExceptions;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import io.vertx.core.Future;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpClientResponse;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import org.apache.commons.lang3.StringUtils;
+
+import org.folio.rest.client.ConfigurationsClient;
+import org.folio.util.OkapiParams;
+
+public class ModConfiguration implements Configuration {
+
+  private static final String PROP_VALUE = "value";
+  private static final String PROP_BY_CODE_QUERY = "module==%s AND code==%s";
+
+  private String module;
+
+
+  public ModConfiguration(String module) {
+    if (StringUtils.isBlank(module)) {
+      throw new IllegalArgumentException("Module name cannot be empty");
+    }
+    this.module = module;
+  }
+
+  @Override
+  public Future<String> getString(String code, OkapiParams params) {
+    return getValue(code, value(), params);
+  }
+
+  @Override
+  public Future<String> getString(String code, String def, OkapiParams params) {
+    return getString(code, params).otherwise(def);
+  }
+
+  @Override
+  public Future<Integer> getInt(String code, OkapiParams params) {
+    return getValue(code, value().andThen(convert(Integer::valueOf)), params);
+  }
+
+  @Override
+  public Future<Integer> getInt(String code, int def, OkapiParams params) {
+    return getInt(code, params).otherwise(def);
+  }
+
+  @Override
+  public Future<Long> getLong(String code, OkapiParams params) {
+    return getValue(code, value().andThen(convert(Long::valueOf)), params);
+  }
+
+  @Override
+  public Future<Long> getLong(String code, long def, OkapiParams params) {
+    return getLong(code, params).otherwise(def);
+  }
+
+  @Override
+  public Future<Double> getDouble(String code, OkapiParams params) {
+    return getValue(code, value().andThen(convert(Double::valueOf)), params);
+  }
+
+  @Override
+  public Future<Double> getDouble(String code, double def, OkapiParams params) {
+    return getDouble(code, params).otherwise(def);
+  }
+
+  @Override
+  public Future<Boolean> getBoolean(String code, OkapiParams params) {
+    return getValue(code, value().andThen(convert(Boolean::valueOf)), params);
+  }
+
+  @Override
+  public Future<Boolean> getBoolean(String code, boolean def, OkapiParams params) {
+    return getBoolean(code, params).otherwise(def);
+  }
+
+  private <T> Future<T> getValue(String code, Function<JsonObject, T> valueExtractor, OkapiParams params) {
+    // make sure non config exception is wrapped into ConfigurationException
+    return wrapExceptions(
+              getConfigObject(code, params)
+                .map(valueExtractor)
+                .map(value -> failIfNull(code, value)),
+              ConfigurationException.class);
+  }
+
+  private <T> T failIfNull(String propertyCode, T value) {
+    if (value != null) {
+      return value;
+    } else {
+      throw new ValueNotDefinedException(propertyCode);
+    }
+  }
+
+  private Future<JsonObject> getConfigObject(String code, OkapiParams params) {
+    Future<JsonObject> result = Future.future();
+
+    try {
+      ConfigurationsClient configurationsClient = new ConfigurationsClient(params.getHost(), params.getPort(),
+        params.getTenant(), params.getToken());
+
+      String query = format(PROP_BY_CODE_QUERY, module, code);
+
+      configurationsClient.getEntries(query, 0, 10, null, null, response ->
+        response.bodyHandler(body -> handleResponseBody(response, body, code, result))
+      );
+    } catch (Exception e) {
+      result.fail(e);
+    }
+
+    return result;
+  }
+
+  private void handleResponseBody(HttpClientResponse response, Buffer body, String code, Future<JsonObject> future) {
+    if (response.statusCode() == 200) {
+      try {
+        future.complete(retrievePropObject(code, body));
+      } catch (Exception e) {
+        future.fail(e);
+      }
+    } else {
+      future.fail(new ConfigurationException(
+        format("Configuration property cannot be retrieved: code = %s. " +
+          "Response details: status = %d, body = '%s'", code, response.statusCode(), body.toString())));
+    }
+  }
+
+  private JsonObject retrievePropObject(String code, Buffer body) {
+    JsonObject entries = body.toJsonObject();
+
+    JsonArray configs = defaultIfNull(entries.getJsonArray("configs"), new JsonArray());
+
+    List<JsonObject> enabled = configs.stream()
+      .map(JsonObject.class::cast)
+      .filter(config -> config.getBoolean("enabled", true))
+      .collect(Collectors.toList());
+
+    switch (enabled.size()) {
+      case 0: throw new PropertyNotFoundException(code);
+      case 1: return enabled.get(0);
+      default: throw new PropertyException(code, "more than one configuration properties found");
+    }
+  }
+
+  private static Function<JsonObject, String> value() {
+    return json -> {
+      String value = json.getString(PROP_VALUE);
+      return StringUtils.isNotBlank(value) ? value : null;
+    };
+  }
+
+  private static <T> Function<String, T> convert(Function<String, T> conversion) {
+    return s -> s != null ? conversion.apply(s) : null;
+  }
+  
+}

--- a/src/main/java/org/folio/config/PropertyException.java
+++ b/src/main/java/org/folio/config/PropertyException.java
@@ -1,0 +1,30 @@
+package org.folio.config;
+
+public class PropertyException extends ConfigurationException {
+
+  private final String propertyCode;
+
+  public PropertyException(String propertyCode, String message) {
+    super(message);
+    this.propertyCode = propertyCode;
+  }
+
+  public PropertyException(String propertyCode, Throwable cause) {
+    super(cause);
+    this.propertyCode = propertyCode;
+  }
+
+  public PropertyException(String propertyCode, String message, Throwable cause) {
+    super(message, cause);
+    this.propertyCode = propertyCode;
+  }
+
+  public String getPropertyCode() {
+    return propertyCode;
+  }
+
+  @Override
+  public String getMessage() {
+    return "Configuration property '" + propertyCode + "' exception: " + super.getMessage();
+  }
+}

--- a/src/main/java/org/folio/config/PropertyNotFoundException.java
+++ b/src/main/java/org/folio/config/PropertyNotFoundException.java
@@ -1,0 +1,10 @@
+package org.folio.config;
+
+@SuppressWarnings("squid:MaximumInheritanceDepth")
+public class PropertyNotFoundException extends PropertyException {
+
+  public PropertyNotFoundException(String propertyCode) {
+    super(propertyCode, "property is not found");
+  }
+
+}

--- a/src/main/java/org/folio/config/ValueNotDefinedException.java
+++ b/src/main/java/org/folio/config/ValueNotDefinedException.java
@@ -1,0 +1,10 @@
+package org.folio.config;
+
+@SuppressWarnings("squid:MaximumInheritanceDepth")
+public class ValueNotDefinedException extends PropertyException {
+
+  public ValueNotDefinedException(String propertyCode) {
+    super(propertyCode, "value is not defined");
+  }
+
+}

--- a/src/main/java/org/folio/rest/exc/ExceptionHandlers.java
+++ b/src/main/java/org/folio/rest/exc/ExceptionHandlers.java
@@ -9,6 +9,7 @@ import javax.ws.rs.NotFoundException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import com.github.mauricio.async.db.postgresql.exceptions.GenericDatabaseException;
 import io.vertx.core.Future;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
@@ -35,6 +36,7 @@ public class ExceptionHandlers {
     //
     // the below is to show how predicates that potentially have complex logic can be combined
     return pf(instanceOf(BadRequestException.class)
+                .or(instanceOf(GenericDatabaseException.class).and(invalidUUID()))
                 .or(instanceOf(CQLQueryValidationException.class))
                 .or(instanceOf(CQL2PgJSONException.class)),
               ExceptionHandlers::toBadRequest);
@@ -80,6 +82,10 @@ public class ExceptionHandlers {
 
   private static Predicate<Throwable> instanceOf(Class<? extends Throwable> cl) {
     return new InstanceOfPredicate<>(cl);
+  }
+
+  private static Predicate<Throwable> invalidUUID() {
+    return t -> ValidationHelper.isInvalidUUID(t.getMessage());
   }
 
   private static class InstanceOfPredicate<T, E> implements Predicate<E> {

--- a/src/main/java/org/folio/rest/exc/ExceptionHandlers.java
+++ b/src/main/java/org/folio/rest/exc/ExceptionHandlers.java
@@ -1,4 +1,4 @@
-package org.folio.util.exc;
+package org.folio.rest.exc;
 
 import static org.folio.util.pf.PartialFunctions.pf;
 

--- a/src/main/java/org/folio/rest/impl/InitAPIImpl.java
+++ b/src/main/java/org/folio/rest/impl/InitAPIImpl.java
@@ -1,0 +1,31 @@
+package org.folio.rest.impl;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+
+import org.folio.rest.resource.interfaces.InitAPI;
+import org.folio.spring.SpringContextUtil;
+import org.folio.spring.config.ApplicationConfig;
+
+public class InitAPIImpl implements InitAPI {
+
+  @Override
+  public void init(Vertx vertx, Context context, Handler<AsyncResult<Boolean>> handler) {
+    vertx.executeBlocking(
+      future -> {
+        SpringContextUtil.init(vertx, context, ApplicationConfig.class);
+        future.complete();
+      },
+      result -> {
+        if (result.succeeded()) {
+          handler.handle(Future.succeededFuture(true));
+        } else {
+          handler.handle(Future.failedFuture(result.cause()));
+        }
+      });
+  }
+
+}

--- a/src/main/java/org/folio/rest/impl/NoteTypesImpl.java
+++ b/src/main/java/org/folio/rest/impl/NoteTypesImpl.java
@@ -22,6 +22,7 @@ import org.folio.rest.jaxrs.model.NoteTypeUsage;
 import org.folio.rest.jaxrs.resource.NoteTypes;
 import org.folio.spring.SpringContextUtil;
 import org.folio.type.NoteTypeService;
+import org.folio.util.OkapiParams;
 import org.folio.util.pf.PartialFunction;
 
 public class NoteTypesImpl implements NoteTypes {
@@ -50,7 +51,7 @@ public class NoteTypesImpl implements NoteTypes {
   @Override
   public void postNoteTypes(String lang, NoteType entity, Map<String, String> okapiHeaders,
       Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
-    Future<NoteType> saved = typeService.save(entity, tenantId(okapiHeaders));
+    Future<NoteType> saved = typeService.save(entity, new OkapiParams(okapiHeaders));
 
     respond(saved,
       noteType -> PostNoteTypesResponse.respond201WithApplicationJson(noteType, PostNoteTypesResponse.headersFor201()),

--- a/src/main/java/org/folio/rest/impl/NoteTypesImpl.java
+++ b/src/main/java/org/folio/rest/impl/NoteTypesImpl.java
@@ -22,13 +22,14 @@ import org.folio.rest.jaxrs.model.NoteTypeUsage;
 import org.folio.rest.jaxrs.resource.NoteTypes;
 import org.folio.spring.SpringContextUtil;
 import org.folio.type.NoteTypeService;
+import org.folio.util.pf.PartialFunction;
 
 public class NoteTypesImpl implements NoteTypes {
 
   @Autowired
   private NoteTypeService typeService;
   @Autowired @Qualifier("default")
-  private Function<Throwable, Response> exceptionHandler;
+  private PartialFunction<Throwable, Response> exceptionHandler;
 
 
   public NoteTypesImpl() {

--- a/src/main/java/org/folio/rest/impl/NoteTypesImpl.java
+++ b/src/main/java/org/folio/rest/impl/NoteTypesImpl.java
@@ -41,12 +41,6 @@ public class NoteTypesImpl implements NoteTypes {
       Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     Future<NoteTypeCollection> found = typeService.findByQuery(query, offset, limit, lang, tenantId(okapiHeaders));
 
-    /*found.map(col -> updateNoteTypeUsage(col, 0))
-      .map(GetNoteTypesResponse::respond200WithApplicationJson)
-      .map(Response.class::cast)
-      .otherwise(exceptionHandler)
-      .setHandler(asyncResultHandler);*/
-
     respond(found.map(col -> updateNoteTypeUsage(col, 0)), // temporarily, until the usage is not calculated
       GetNoteTypesResponse::respond200WithApplicationJson,
       asyncResultHandler);
@@ -58,11 +52,6 @@ public class NoteTypesImpl implements NoteTypes {
       Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     Future<NoteType> saved = typeService.save(entity, tenantId(okapiHeaders));
 
-    /*saved.map(e -> PostNoteTypesResponse.respond201WithApplicationJson(e, PostNoteTypesResponse.headersFor201()))
-      .map(Response.class::cast)
-      .otherwise(exceptionHandler)
-      .setHandler(asyncResultHandler);*/
-
     respond(saved,
       noteType -> PostNoteTypesResponse.respond201WithApplicationJson(noteType, PostNoteTypesResponse.headersFor201()),
       asyncResultHandler);
@@ -73,15 +62,6 @@ public class NoteTypesImpl implements NoteTypes {
   public void getNoteTypesByTypeId(String typeId, String lang, Map<String, String> okapiHeaders,
                                    Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     Future<NoteType> found = typeService.findById(typeId, tenantId(okapiHeaders));
-
-    /*found.map(noteType -> { // temporarily, until the usage is not calculated
-        noteType.setUsage(new NoteTypeUsage().withNoteTotal(0));
-        return noteType;
-      }) 
-      .map(GetNoteTypesByTypeIdResponse::respond200WithApplicationJson)
-      .map(Response.class::cast)
-      .otherwise(exceptionHandler)
-      .setHandler(asyncResultHandler);*/
 
     respond(found.map(noteType -> { // temporarily, until the usage is not calculated
                 noteType.setUsage(new NoteTypeUsage().withNoteTotal(0));
@@ -97,11 +77,6 @@ public class NoteTypesImpl implements NoteTypes {
       Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     Future<Void> deleted = typeService.delete(typeId, tenantId(okapiHeaders));
 
-    /*deleted.map(DeleteNoteTypesByTypeIdResponse.respond204())
-      .map(Response.class::cast)
-      .otherwise(exceptionHandler)
-      .setHandler(asyncResultHandler);*/
-
     respond(deleted, v -> DeleteNoteTypesByTypeIdResponse.respond204(), asyncResultHandler);
   }
 
@@ -109,11 +84,6 @@ public class NoteTypesImpl implements NoteTypes {
   public void putNoteTypesByTypeId(String typeId, String lang, NoteType entity, Map<String, String> okapiHeaders,
       Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     Future<Void> updated = typeService.update(typeId, entity, tenantId(okapiHeaders));
-
-    /*updated.map(PutNoteTypesByTypeIdResponse.respond204())
-      .map(Response.class::cast)
-      .otherwise(exceptionHandler)
-      .setHandler(asyncResultHandler);*/
 
     respond(updated, v -> PutNoteTypesByTypeIdResponse.respond204(), asyncResultHandler);
   }

--- a/src/main/java/org/folio/rest/impl/NoteTypesImpl.java
+++ b/src/main/java/org/folio/rest/impl/NoteTypesImpl.java
@@ -29,7 +29,7 @@ public class NoteTypesImpl implements NoteTypes {
 
   @Autowired
   private NoteTypeService typeService;
-  @Autowired @Qualifier("default")
+  @Autowired @Qualifier("defaultExcHandler")
   private PartialFunction<Throwable, Response> exceptionHandler;
 
 
@@ -84,7 +84,7 @@ public class NoteTypesImpl implements NoteTypes {
   @Override
   public void putNoteTypesByTypeId(String typeId, String lang, NoteType entity, Map<String, String> okapiHeaders,
       Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
-    Future<Void> updated = typeService.update(typeId, entity, tenantId(okapiHeaders));
+    Future<Void> updated = typeService.update(typeId, entity, new OkapiParams(okapiHeaders));
 
     respond(updated, v -> PutNoteTypesByTypeIdResponse.respond204(), asyncResultHandler);
   }

--- a/src/main/java/org/folio/rest/impl/NotesResourceImpl.java
+++ b/src/main/java/org/folio/rest/impl/NotesResourceImpl.java
@@ -9,6 +9,7 @@ import java.util.Objects;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import javax.ws.rs.BadRequestException;
 import javax.ws.rs.NotAuthorizedException;
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.core.Response;
@@ -165,11 +166,9 @@ public class NotesResourceImpl implements Notes {
         saveNote(note, okapiHeaders, context, asyncResultHandler);
         return null;
       }).otherwise(exception -> {
-        final Throwable exceptionCause = exception.getCause();
-        if (exceptionCause instanceof NotFoundException || exceptionCause instanceof NotAuthorizedException ||
-            exceptionCause instanceof IllegalArgumentException || exceptionCause instanceof IllegalStateException) {
-          asyncResultHandler.handle(succeededFuture(PostNotesResponse.respond400WithTextPlain(exceptionCause.getMessage())));
-        }else if(exception instanceof IllegalArgumentException){
+        if (exception instanceof NotFoundException || exception instanceof NotAuthorizedException ||
+            exception instanceof IllegalArgumentException || exception instanceof IllegalStateException ||
+            exception instanceof BadRequestException) {
           asyncResultHandler.handle(succeededFuture(PostNotesResponse.respond400WithTextPlain(exception.getMessage())));
         } else {
           asyncResultHandler.handle(succeededFuture(PostNotesResponse.respond500WithTextPlain(exception.getMessage())));

--- a/src/main/java/org/folio/spring/config/ApplicationConfig.java
+++ b/src/main/java/org/folio/spring/config/ApplicationConfig.java
@@ -7,6 +7,7 @@ import static org.folio.rest.exc.ExceptionHandlers.notFoundHandler;
 
 import javax.ws.rs.core.Response;
 
+import com.rits.cloning.Cloner;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
@@ -34,7 +35,7 @@ public class ApplicationConfig {
     return Messages.getInstance();
   }
 
-  @Bean("default")
+  @Bean
   public PartialFunction<Throwable, Response> defaultExcHandler() {
     return logged(badRequestHandler()
                 .orElse(notFoundHandler())
@@ -44,5 +45,10 @@ public class ApplicationConfig {
   @Bean
   public org.folio.config.Configuration configuration(@Value("${note.configuration.module}") String module) {
     return new ModConfiguration(module);
+  }
+
+  @Bean
+  public Cloner restModelCloner() {
+    return new Cloner();
   }
 }

--- a/src/main/java/org/folio/spring/config/ApplicationConfig.java
+++ b/src/main/java/org/folio/spring/config/ApplicationConfig.java
@@ -1,0 +1,26 @@
+package org.folio.spring.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
+import org.springframework.core.io.ClassPathResource;
+
+import org.folio.rest.tools.messages.Messages;
+
+@Configuration
+@ComponentScan(basePackages = {"org.folio.type"})
+public class ApplicationConfig {
+
+  @Bean
+  public PropertySourcesPlaceholderConfigurer placeholderConfigurer() {
+    PropertySourcesPlaceholderConfigurer configurer = new PropertySourcesPlaceholderConfigurer();
+    configurer.setLocation(new ClassPathResource("application.properties"));
+    return configurer;
+  }
+
+  @Bean
+  public Messages messages() {
+    return Messages.getInstance();
+  }
+}

--- a/src/main/java/org/folio/spring/config/ApplicationConfig.java
+++ b/src/main/java/org/folio/spring/config/ApplicationConfig.java
@@ -1,18 +1,20 @@
 package org.folio.spring.config;
 
-import static org.folio.util.exc.ExceptionHandlers.badRequestHandler;
-import static org.folio.util.exc.ExceptionHandlers.generalHandler;
-import static org.folio.util.exc.ExceptionHandlers.logged;
-import static org.folio.util.exc.ExceptionHandlers.notFoundHandler;
+import static org.folio.rest.exc.ExceptionHandlers.badRequestHandler;
+import static org.folio.rest.exc.ExceptionHandlers.generalHandler;
+import static org.folio.rest.exc.ExceptionHandlers.logged;
+import static org.folio.rest.exc.ExceptionHandlers.notFoundHandler;
 
 import javax.ws.rs.core.Response;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
 import org.springframework.core.io.ClassPathResource;
 
+import org.folio.config.ModConfiguration;
 import org.folio.rest.tools.messages.Messages;
 import org.folio.util.pf.PartialFunction;
 
@@ -37,5 +39,10 @@ public class ApplicationConfig {
     return logged(badRequestHandler()
                 .orElse(notFoundHandler())
                 .orElse(generalHandler()));
+  }
+
+  @Bean
+  public org.folio.config.Configuration configuration(@Value("${note.configuration.module}") String module) {
+    return new ModConfiguration(module);
   }
 }

--- a/src/main/java/org/folio/spring/config/ApplicationConfig.java
+++ b/src/main/java/org/folio/spring/config/ApplicationConfig.java
@@ -1,5 +1,14 @@
 package org.folio.spring.config;
 
+import static org.folio.util.exc.ExceptionHandlers.badRequestHandler;
+import static org.folio.util.exc.ExceptionHandlers.generalHandler;
+import static org.folio.util.exc.ExceptionHandlers.logged;
+import static org.folio.util.exc.ExceptionHandlers.notFoundHandler;
+
+import java.util.function.Function;
+
+import javax.ws.rs.core.Response;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
@@ -22,5 +31,12 @@ public class ApplicationConfig {
   @Bean
   public Messages messages() {
     return Messages.getInstance();
+  }
+
+  @Bean("default")
+  public Function<Throwable, Response> defaultExcHandler() {
+    return logged(badRequestHandler()
+                .orElse(notFoundHandler())
+                .orElse(generalHandler()));
   }
 }

--- a/src/main/java/org/folio/spring/config/ApplicationConfig.java
+++ b/src/main/java/org/folio/spring/config/ApplicationConfig.java
@@ -5,8 +5,6 @@ import static org.folio.util.exc.ExceptionHandlers.generalHandler;
 import static org.folio.util.exc.ExceptionHandlers.logged;
 import static org.folio.util.exc.ExceptionHandlers.notFoundHandler;
 
-import java.util.function.Function;
-
 import javax.ws.rs.core.Response;
 
 import org.springframework.context.annotation.Bean;
@@ -16,6 +14,7 @@ import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
 import org.springframework.core.io.ClassPathResource;
 
 import org.folio.rest.tools.messages.Messages;
+import org.folio.util.pf.PartialFunction;
 
 @Configuration
 @ComponentScan(basePackages = {"org.folio.type"})
@@ -34,7 +33,7 @@ public class ApplicationConfig {
   }
 
   @Bean("default")
-  public Function<Throwable, Response> defaultExcHandler() {
+  public PartialFunction<Throwable, Response> defaultExcHandler() {
     return logged(badRequestHandler()
                 .orElse(notFoundHandler())
                 .orElse(generalHandler()));

--- a/src/main/java/org/folio/type/NoteTypeRepository.java
+++ b/src/main/java/org/folio/type/NoteTypeRepository.java
@@ -16,6 +16,8 @@ public interface NoteTypeRepository {
 
   Future<List<NoteType>> findByIds(List<String> ids, String tenantId);
 
+  Future<Long> count(String tenantId);
+
   Future<NoteType> save(NoteType entity, String tenantId);
 
   Future<Boolean> update(NoteType entity, String tenantId);

--- a/src/main/java/org/folio/type/NoteTypeRepository.java
+++ b/src/main/java/org/folio/type/NoteTypeRepository.java
@@ -1,0 +1,22 @@
+package org.folio.type;
+
+import java.util.List;
+import java.util.Optional;
+
+import io.vertx.core.Future;
+
+import org.folio.rest.jaxrs.model.NoteType;
+import org.folio.rest.jaxrs.model.NoteTypeCollection;
+
+public interface NoteTypeRepository {
+
+  Future<NoteTypeCollection> findByQuery(String query, int offset, int limit, String tenantId);
+
+  Future<Optional<NoteType>> findById(String id, String tenantId);
+
+  Future<List<NoteType>> findByIds(List<String> ids, String tenantId);
+
+  Future<NoteType> save(NoteType entity, String tenantId);
+
+  Future<Boolean> delete(String id, String tenantId);
+}

--- a/src/main/java/org/folio/type/NoteTypeRepository.java
+++ b/src/main/java/org/folio/type/NoteTypeRepository.java
@@ -18,5 +18,7 @@ public interface NoteTypeRepository {
 
   Future<NoteType> save(NoteType entity, String tenantId);
 
+  Future<Boolean> update(NoteType entity, String tenantId);
+
   Future<Boolean> delete(String id, String tenantId);
 }

--- a/src/main/java/org/folio/type/NoteTypeRepositoryImpl.java
+++ b/src/main/java/org/folio/type/NoteTypeRepositoryImpl.java
@@ -11,6 +11,7 @@ import java.util.Optional;
 
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
+import io.vertx.ext.sql.ResultSet;
 import io.vertx.ext.sql.UpdateResult;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -26,6 +27,7 @@ import org.folio.rest.persist.interfaces.Results;
 public class NoteTypeRepositoryImpl implements NoteTypeRepository {
 
   private static final String NOTE_TYPE_TABLE = "note_type";
+  private static final String SELECT_TOTAL_COUNT = "SELECT count(*) FROM " + NOTE_TYPE_TABLE;
 
   private Vertx vertx;
 
@@ -58,6 +60,15 @@ public class NoteTypeRepositoryImpl implements NoteTypeRepository {
     pgClient(tenantId).getById(NOTE_TYPE_TABLE, createParams(ids), NoteType.class, future);
 
     return future.map(resultMap -> new ArrayList<>(resultMap.values()));
+  }
+
+  @Override
+  public Future<Long> count(String tenantId) {
+    Future<ResultSet> resultSetFuture = Future.future();
+
+    pgClient(tenantId).select(SELECT_TOTAL_COUNT, resultSetFuture);
+
+    return resultSetFuture.map(rs -> rs.getResults().get(0).getLong(0));
   }
 
   @Override

--- a/src/main/java/org/folio/type/NoteTypeRepositoryImpl.java
+++ b/src/main/java/org/folio/type/NoteTypeRepositoryImpl.java
@@ -64,9 +64,18 @@ public class NoteTypeRepositoryImpl implements NoteTypeRepository {
   public Future<NoteType> save(NoteType entity, String tenantId) {
     Future<String> future = Future.future(); // future with id as result
 
-    pgClient(tenantId).save(NOTE_TYPE_TABLE, entity.getId(), entity, true, true, true, future);
+    pgClient(tenantId).save(NOTE_TYPE_TABLE, entity.getId(), entity, future);
 
     return future.map(id -> updateId(entity, id)); // update id only, copy the rest from the original entity
+  }
+
+  @Override
+  public Future<Boolean> update(NoteType entity, String tenantId) {
+    Future<UpdateResult> future = Future.future();
+
+    pgClient(tenantId).update(NOTE_TYPE_TABLE, entity, entity.getId(), future);
+
+    return future.map(updateResult -> updateResult.getUpdated() == 1);
   }
 
   @Override

--- a/src/main/java/org/folio/type/NoteTypeRepositoryImpl.java
+++ b/src/main/java/org/folio/type/NoteTypeRepositoryImpl.java
@@ -1,0 +1,128 @@
+package org.folio.type;
+
+import static org.folio.util.DbUtils.ALL_FIELDS;
+import static org.folio.util.DbUtils.createParams;
+import static org.folio.util.DbUtils.getCQLWrapper;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.ext.sql.UpdateResult;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.z3950.zing.cql.cql2pgjson.FieldException;
+
+import org.folio.rest.jaxrs.model.NoteType;
+import org.folio.rest.jaxrs.model.NoteTypeCollection;
+import org.folio.rest.persist.PostgresClient;
+import org.folio.rest.persist.cql.CQLWrapper;
+import org.folio.rest.persist.interfaces.Results;
+
+@Component
+public class NoteTypeRepositoryImpl implements NoteTypeRepository {
+
+  private static final String NOTE_TYPE_TABLE = "note_type";
+
+  private Vertx vertx;
+
+
+  @Autowired
+  public NoteTypeRepositoryImpl(Vertx vertx) {
+    this.vertx = vertx;
+  }
+
+  @Override
+  public Future<NoteTypeCollection> findByQuery(String query, int offset, int limit, String tenantId) {
+    CqlQuery<NoteType> q = new CqlQuery<>(pgClient(tenantId), NOTE_TYPE_TABLE, NoteType.class);
+
+    return q.get(query, offset, limit).map(this::toNoteTypeCollection);
+  }
+
+  @Override
+  public Future<Optional<NoteType>> findById(String id, String tenantId) {
+    Future<NoteType> future = Future.future();
+
+    pgClient(tenantId).getById(NOTE_TYPE_TABLE, id, NoteType.class, future);
+
+    return future.map(Optional::ofNullable);
+  }
+
+  @Override
+  public Future<List<NoteType>> findByIds(List<String> ids, String tenantId) {
+    Future<Map<String, NoteType>> future = Future.future();
+
+    pgClient(tenantId).getById(NOTE_TYPE_TABLE, createParams(ids), NoteType.class, future);
+
+    return future.map(resultMap -> new ArrayList<>(resultMap.values()));
+  }
+
+  @Override
+  public Future<NoteType> save(NoteType entity, String tenantId) {
+    Future<String> future = Future.future(); // future with id as result
+
+    pgClient(tenantId).save(NOTE_TYPE_TABLE, entity.getId(), entity, true, true, true, future);
+
+    return future.map(id -> updateId(entity, id)); // update id only, copy the rest from the original entity
+  }
+
+  @Override
+  public Future<Boolean> delete(String id, String tenantId) {
+    Future<UpdateResult> future = Future.future();
+
+    pgClient(tenantId).delete(NOTE_TYPE_TABLE, id, future);
+
+    return future.map(updateResult -> updateResult.getUpdated() == 1);
+  }
+
+  private PostgresClient pgClient(String tenantId) {
+    return PostgresClient.getInstance(vertx, tenantId);
+  }
+
+  private NoteTypeCollection toNoteTypeCollection(Results<NoteType> results) {
+    return new NoteTypeCollection()
+      .withNoteTypes(results.getResults())
+      .withTotalRecords(results.getResultInfo().getTotalRecords());
+  }
+
+  private NoteType updateId(NoteType entity, String newId) {
+    return new NoteType()
+      .withId(newId)
+      .withName(entity.getName())
+      .withUsage(entity.getUsage()) // don't clone deeply this field
+      .withMetadata(entity.getMetadata()); // don't clone deeply this field
+  }
+
+  private static class CqlQuery<T> {
+
+    private PostgresClient pg;
+    private String table;
+    private Class<T> clazz;
+
+
+    CqlQuery(PostgresClient pg, String table, Class<T> clazz) {
+      this.pg = pg;
+      this.table = table;
+      this.clazz = clazz;
+    }
+
+    Future<Results<T>> get(String cqlQuery, int offset, int limit) {
+      CQLWrapper cql;
+      try {
+        cql = getCQLWrapper(table, cqlQuery, limit, offset);
+      } catch (FieldException e) {
+        return Future.failedFuture(e);
+      }
+
+      Future<Results<T>> future = Future.future();
+      pg.get(table, clazz, ALL_FIELDS, cql, true, false, future);
+
+      return future;
+    }
+
+  }
+
+}

--- a/src/main/java/org/folio/type/NoteTypeRepositoryImpl.java
+++ b/src/main/java/org/folio/type/NoteTypeRepositoryImpl.java
@@ -92,8 +92,8 @@ public class NoteTypeRepositoryImpl implements NoteTypeRepository {
     return new NoteType()
       .withId(newId)
       .withName(entity.getName())
-      .withUsage(entity.getUsage()) // don't clone deeply this field
-      .withMetadata(entity.getMetadata()); // don't clone deeply this field
+      .withUsage(entity.getUsage()) // this field is not cloned deeply
+      .withMetadata(entity.getMetadata()); // this field is not cloned deeply
   }
 
   private static class CqlQuery<T> {

--- a/src/main/java/org/folio/type/NoteTypeRepositoryImpl.java
+++ b/src/main/java/org/folio/type/NoteTypeRepositoryImpl.java
@@ -88,7 +88,9 @@ public class NoteTypeRepositoryImpl implements NoteTypeRepository {
   }
 
   private PostgresClient pgClient(String tenantId) {
-    return PostgresClient.getInstance(vertx, tenantId);
+    PostgresClient pg = PostgresClient.getInstance(vertx, tenantId);
+    pg.setIdField("id");
+    return pg;
   }
 
   private NoteTypeCollection toNoteTypeCollection(Results<NoteType> results) {

--- a/src/main/java/org/folio/type/NoteTypeService.java
+++ b/src/main/java/org/folio/type/NoteTypeService.java
@@ -18,7 +18,7 @@ public interface NoteTypeService {
 
   Future<NoteType> save(NoteType entity, OkapiParams params);
 
-  Future<Void> update(String id, NoteType entity, String tenantId);
+  Future<Void> update(String id, NoteType entity, OkapiParams params);
 
   Future<Void> delete(String id, String tenantId);
 

--- a/src/main/java/org/folio/type/NoteTypeService.java
+++ b/src/main/java/org/folio/type/NoteTypeService.java
@@ -17,6 +17,8 @@ public interface NoteTypeService {
 
   Future<NoteType> save(NoteType entity, String tenantId);
 
-  Future<String> delete(String id, String tenantId);
+  Future<Void> update(String id, NoteType entity, String tenantId);
+
+  Future<Void> delete(String id, String tenantId);
 
 }

--- a/src/main/java/org/folio/type/NoteTypeService.java
+++ b/src/main/java/org/folio/type/NoteTypeService.java
@@ -1,0 +1,22 @@
+package org.folio.type;
+
+import java.util.List;
+import java.util.Optional;
+
+import io.vertx.core.Future;
+
+import org.folio.rest.jaxrs.model.NoteType;
+
+public interface NoteTypeService {
+
+  Future<List<NoteType>> findByQuery(String query, int offset, int limit, String lang, String tenantId);
+
+  Future<Optional<NoteType>> findById(String id, String tenantId);
+
+  Future<List<NoteType>> findByIds(List<String> ids, String tenantId);
+
+  Future<NoteType> save(NoteType entity, String tenantId);
+
+  Future<Boolean> delete(String id, String tenantId);
+
+}

--- a/src/main/java/org/folio/type/NoteTypeService.java
+++ b/src/main/java/org/folio/type/NoteTypeService.java
@@ -6,6 +6,7 @@ import io.vertx.core.Future;
 
 import org.folio.rest.jaxrs.model.NoteType;
 import org.folio.rest.jaxrs.model.NoteTypeCollection;
+import org.folio.util.OkapiParams;
 
 public interface NoteTypeService {
 
@@ -15,7 +16,7 @@ public interface NoteTypeService {
 
   Future<List<NoteType>> findByIds(List<String> ids, String tenantId);
 
-  Future<NoteType> save(NoteType entity, String tenantId);
+  Future<NoteType> save(NoteType entity, OkapiParams params);
 
   Future<Void> update(String id, NoteType entity, String tenantId);
 

--- a/src/main/java/org/folio/type/NoteTypeService.java
+++ b/src/main/java/org/folio/type/NoteTypeService.java
@@ -1,22 +1,22 @@
 package org.folio.type;
 
 import java.util.List;
-import java.util.Optional;
 
 import io.vertx.core.Future;
 
 import org.folio.rest.jaxrs.model.NoteType;
+import org.folio.rest.jaxrs.model.NoteTypeCollection;
 
 public interface NoteTypeService {
 
-  Future<List<NoteType>> findByQuery(String query, int offset, int limit, String lang, String tenantId);
+  Future<NoteTypeCollection> findByQuery(String query, int offset, int limit, String lang, String tenantId);
 
-  Future<Optional<NoteType>> findById(String id, String tenantId);
+  Future<NoteType> findById(String id, String tenantId);
 
   Future<List<NoteType>> findByIds(List<String> ids, String tenantId);
 
   Future<NoteType> save(NoteType entity, String tenantId);
 
-  Future<Boolean> delete(String id, String tenantId);
+  Future<String> delete(String id, String tenantId);
 
 }

--- a/src/main/java/org/folio/type/NoteTypeServiceImpl.java
+++ b/src/main/java/org/folio/type/NoteTypeServiceImpl.java
@@ -43,20 +43,20 @@ public class NoteTypeServiceImpl implements NoteTypeService {
 
   @Override
   public Future<Void> update(String id, NoteType entity, String tenantId) {
-    entity.setId(id);
+    entity.setId(id); // undesirable modification of input entity, but probably safe in this case
 
     return repository.update(entity, tenantId)
-            .compose(updated -> updated
-              ? succeededFuture()
-              : failedFuture(Exceptions.notFound(NoteType.class, id)));
+            .compose(updated -> failIfNotFound(updated, id));
   }
 
   @Override
   public Future<Void> delete(String id, String tenantId) {
     return repository.delete(id, tenantId)
-            .compose(deleted -> deleted
-              ? succeededFuture()
-              : failedFuture(Exceptions.notFound(NoteType.class, id)));
+            .compose(deleted -> failIfNotFound(deleted, id));
+  }
+
+  private Future<Void> failIfNotFound(boolean found, String entityId) {
+    return found ? succeededFuture() : failedFuture(Exceptions.notFound(NoteType.class, entityId));
   }
 
 }

--- a/src/main/java/org/folio/type/NoteTypeServiceImpl.java
+++ b/src/main/java/org/folio/type/NoteTypeServiceImpl.java
@@ -1,0 +1,39 @@
+package org.folio.type;
+
+import java.util.List;
+import java.util.Optional;
+
+import io.vertx.core.Future;
+import org.springframework.stereotype.Component;
+
+import org.folio.rest.jaxrs.model.NoteType;
+
+@Component
+public class NoteTypeServiceImpl implements NoteTypeService {
+
+  @Override
+  public Future<List<NoteType>> findByQuery(String query, int offset, int limit, String lang, String tenantId) {
+    return null;
+  }
+
+  @Override
+  public Future<Optional<NoteType>> findById(String id, String tenantId) {
+    return null;
+  }
+
+  @Override
+  public Future<List<NoteType>> findByIds(List<String> ids, String tenantId) {
+    return null;
+  }
+
+  @Override
+  public Future<NoteType> save(NoteType entity, String tenantId) {
+    return null;
+  }
+
+  @Override
+  public Future<Boolean> delete(String id, String tenantId) {
+    return null;
+  }
+
+}

--- a/src/main/java/org/folio/type/NoteTypeServiceImpl.java
+++ b/src/main/java/org/folio/type/NoteTypeServiceImpl.java
@@ -1,29 +1,35 @@
 package org.folio.type;
 
 import java.util.List;
-import java.util.Optional;
 
 import io.vertx.core.Future;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import org.folio.rest.jaxrs.model.NoteType;
+import org.folio.rest.jaxrs.model.NoteTypeCollection;
+import org.folio.util.exc.Exceptions;
 
 @Component
 public class NoteTypeServiceImpl implements NoteTypeService {
 
+  @Autowired
+  private NoteTypeRepository repository;
+
   @Override
-  public Future<List<NoteType>> findByQuery(String query, int offset, int limit, String lang, String tenantId) {
-    return null;
+  public Future<NoteTypeCollection> findByQuery(String query, int offset, int limit, String lang, String tenantId) {
+    return repository.findByQuery(query, offset, limit, tenantId);
   }
 
   @Override
-  public Future<Optional<NoteType>> findById(String id, String tenantId) {
-    return null;
+  public Future<NoteType> findById(String id, String tenantId) {
+    return repository.findById(id, tenantId)
+            .map(noteType -> noteType.orElseThrow(() -> Exceptions.notFound(NoteType.class, id)));
   }
 
   @Override
   public Future<List<NoteType>> findByIds(List<String> ids, String tenantId) {
-    return null;
+    return repository.findByIds(ids, tenantId);
   }
 
   @Override
@@ -32,8 +38,15 @@ public class NoteTypeServiceImpl implements NoteTypeService {
   }
 
   @Override
-  public Future<Boolean> delete(String id, String tenantId) {
-    return null;
+  public Future<String> delete(String id, String tenantId) {
+    return repository.delete(id, tenantId)
+              .map(deleted -> {
+                if (deleted) {
+                  return id;
+                } else {
+                  throw Exceptions.notFound(NoteType.class, id);
+                }
+              });
   }
 
 }

--- a/src/main/java/org/folio/type/NoteTypeServiceImpl.java
+++ b/src/main/java/org/folio/type/NoteTypeServiceImpl.java
@@ -1,5 +1,8 @@
 package org.folio.type;
 
+import static io.vertx.core.Future.failedFuture;
+import static io.vertx.core.Future.succeededFuture;
+
 import java.util.List;
 
 import io.vertx.core.Future;
@@ -34,19 +37,26 @@ public class NoteTypeServiceImpl implements NoteTypeService {
 
   @Override
   public Future<NoteType> save(NoteType entity, String tenantId) {
-    return null;
+    // TODO (Dima Tkachenko): call mod config to test for max number of types
+    return repository.save(entity, tenantId);
   }
 
   @Override
-  public Future<String> delete(String id, String tenantId) {
+  public Future<Void> update(String id, NoteType entity, String tenantId) {
+    entity.setId(id);
+
+    return repository.update(entity, tenantId)
+            .compose(updated -> updated
+              ? succeededFuture()
+              : failedFuture(Exceptions.notFound(NoteType.class, id)));
+  }
+
+  @Override
+  public Future<Void> delete(String id, String tenantId) {
     return repository.delete(id, tenantId)
-              .map(deleted -> {
-                if (deleted) {
-                  return id;
-                } else {
-                  throw Exceptions.notFound(NoteType.class, id);
-                }
-              });
+            .compose(deleted -> deleted
+              ? succeededFuture()
+              : failedFuture(Exceptions.notFound(NoteType.class, id)));
   }
 
 }

--- a/src/main/java/org/folio/userlookup/UserLookUp.java
+++ b/src/main/java/org/folio/userlookup/UserLookUp.java
@@ -2,6 +2,7 @@ package org.folio.userlookup;
 
 import java.util.Map;
 
+import javax.ws.rs.BadRequestException;
 import javax.ws.rs.NotAuthorizedException;
 import javax.ws.rs.NotFoundException;
 
@@ -91,7 +92,7 @@ public class UserLookUp {
     Future<UserLookUp> future = Future.future();
     if (userId == null) {
       logger.error("No userid header");
-      future.fail(new IllegalArgumentException("Missing user id header, cannot look up user"));
+      future.fail(new BadRequestException("Missing user id header, cannot look up user"));
       return future;
     }
     
@@ -120,7 +121,7 @@ public class UserLookUp {
         })
         .thenAccept(future::complete)
         .exceptionally(e -> {
-          future.fail(e);
+          future.fail(e.getCause());
           return null;
         });
     } catch (Exception e) {
@@ -144,7 +145,7 @@ public class UserLookUp {
         userInfo.lastName = personalInfo.getString("lastName");
       }
     } else {
-      throw new IllegalArgumentException("Missing fields");
+      throw new BadRequestException("Missing fields");
     }
     return userInfo;
   }

--- a/src/main/java/org/folio/userlookup/UserLookUp.java
+++ b/src/main/java/org/folio/userlookup/UserLookUp.java
@@ -6,6 +6,7 @@ import javax.ws.rs.NotAuthorizedException;
 import javax.ws.rs.NotFoundException;
 
 import io.vertx.core.Future;
+import io.vertx.core.http.CaseInsensitiveHeaders;
 import io.vertx.core.json.JsonObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -82,8 +83,11 @@ public class UserLookUp {
    * @return User information based on userid from header.
    */
   public static Future<UserLookUp> getUserInfo(final Map<String, String> okapiHeaders) {
-    final String tenantId = TenantTool.calculateTenantId(okapiHeaders.get(RestVerticle.OKAPI_HEADER_TENANT));
-    final String userId = okapiHeaders.get(RestVerticle.OKAPI_USERID_HEADER);
+    CaseInsensitiveHeaders headers = new CaseInsensitiveHeaders();
+    headers.addAll(okapiHeaders);
+    
+    final String tenantId = TenantTool.calculateTenantId(headers.get(RestVerticle.OKAPI_HEADER_TENANT));
+    final String userId = headers.get(RestVerticle.OKAPI_USERID_HEADER);
     Future<UserLookUp> future = Future.future();
     if (userId == null) {
       logger.error("No userid header");
@@ -91,7 +95,7 @@ public class UserLookUp {
       return future;
     }
     
-    String okapiURL = okapiHeaders.get(XOkapiHeaders.URL);
+    String okapiURL = headers.get(XOkapiHeaders.URL);
     String url = "/users/" + userId;
     try {
       final HttpClientInterface httpClient = HttpClientFactory.getHttpClient(okapiURL, tenantId);

--- a/src/main/java/org/folio/util/DbUtils.java
+++ b/src/main/java/org/folio/util/DbUtils.java
@@ -1,0 +1,36 @@
+package org.folio.util;
+
+import io.vertx.core.json.JsonArray;
+import org.z3950.zing.cql.cql2pgjson.CQL2PgJSON;
+import org.z3950.zing.cql.cql2pgjson.FieldException;
+
+import org.folio.rest.persist.Criteria.Limit;
+import org.folio.rest.persist.Criteria.Offset;
+import org.folio.rest.persist.cql.CQLWrapper;
+
+public final class DbUtils {
+
+  public static final String[] ALL_FIELDS = {"*"};
+
+  
+  private DbUtils() {}
+
+  public static CQLWrapper getCQLWrapper(String tableName, String query, int limit, int offset) throws FieldException {
+    return getCQLWrapper(tableName, query)
+            .setLimit(new Limit(limit))
+            .setOffset(new Offset(offset));
+  }
+
+  public static CQLWrapper getCQLWrapper(String tableName, String query) throws FieldException {
+    CQL2PgJSON cql2pgJson = new CQL2PgJSON(tableName + ".jsonb");
+    return new CQLWrapper(cql2pgJson, query);
+  }
+
+  public static JsonArray createParams(Iterable<?> queryParameters) {
+    JsonArray parameters = new JsonArray();
+
+    queryParameters.forEach(parameters::add);
+
+    return parameters;
+  }
+}

--- a/src/main/java/org/folio/util/DbUtils.java
+++ b/src/main/java/org/folio/util/DbUtils.java
@@ -10,6 +10,7 @@ import org.folio.rest.persist.cql.CQLWrapper;
 
 public final class DbUtils {
 
+  @SuppressWarnings("squid:S2386")
   public static final String[] ALL_FIELDS = {"*"};
 
   

--- a/src/main/java/org/folio/util/FutureUtils.java
+++ b/src/main/java/org/folio/util/FutureUtils.java
@@ -1,0 +1,41 @@
+package org.folio.util;
+
+import java.lang.reflect.InvocationTargetException;
+
+import io.vertx.core.Future;
+import org.apache.commons.lang3.reflect.ConstructorUtils;
+
+public final class FutureUtils {
+
+  private FutureUtils() {
+  }
+
+  public static  <T> Future<T> wrapExceptions(Future<T> future, Class<? extends Throwable> wrapperExcClass) {
+    Future<T> result = Future.future();
+
+    future.setHandler(ar -> {
+      if (ar.succeeded()) {
+        result.complete(ar.result());
+      } else {
+
+        Throwable exc;
+
+        if (wrapperExcClass.isInstance(ar.cause())) {
+          exc = ar.cause();
+        } else {
+          try {
+            exc = ConstructorUtils.invokeConstructor(wrapperExcClass, ar.cause());
+          } catch (NoSuchMethodException | InstantiationException | IllegalAccessException
+            | InvocationTargetException e) {
+            exc = e;
+          }
+        }
+
+        result.fail(exc);
+      }
+    });
+
+    return result;
+  }
+
+}

--- a/src/main/java/org/folio/util/OkapiParams.java
+++ b/src/main/java/org/folio/util/OkapiParams.java
@@ -2,6 +2,7 @@ package org.folio.util;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.HashMap;
 import java.util.Map;
 
 import io.vertx.core.http.CaseInsensitiveHeaders;
@@ -36,10 +37,20 @@ public class OkapiParams {
     this.port = url.getPort() != -1 ? url.getPort() : url.getDefaultPort();
   }
 
-  public CaseInsensitiveHeaders getAllHeaders() {
+  public CaseInsensitiveHeaders getHeaders() {
     // make a copy to avoid any modifications to contained headers
     CaseInsensitiveHeaders result = new CaseInsensitiveHeaders();
     result.addAll(headers);
+    return result;
+  }
+
+  public Map<String, String> getHeadersAsMap() {
+    Map<String, String> result = new HashMap<>(headers.size());
+
+    for (Map.Entry<String, String> header : headers) {
+      result.put(header.getKey(), header.getValue());
+    }
+    
     return result;
   }
 

--- a/src/main/java/org/folio/util/OkapiParams.java
+++ b/src/main/java/org/folio/util/OkapiParams.java
@@ -1,0 +1,72 @@
+package org.folio.util;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Map;
+
+import io.vertx.core.http.CaseInsensitiveHeaders;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+import org.folio.okapi.common.XOkapiHeaders;
+
+public class OkapiParams {
+
+  private CaseInsensitiveHeaders headers;
+
+  private String host;
+  private int port;
+  private String token;
+  private String tenant;
+
+
+  public OkapiParams(Map<String, String> headers) {
+    this.headers = new CaseInsensitiveHeaders();
+    this.headers.addAll(headers);
+
+    this.token = headers.get(XOkapiHeaders.TOKEN);
+    this.tenant = headers.get(XOkapiHeaders.TENANT);
+
+    URL url;
+    try {
+      url = new URL(headers.get(XOkapiHeaders.URL));
+    } catch (MalformedURLException e) {
+      throw new IllegalArgumentException("Okapi url header contains invalid value: " + headers.get(XOkapiHeaders.URL));
+    }
+    this.host = url.getHost();
+    this.port = url.getPort() != -1 ? url.getPort() : url.getDefaultPort();
+  }
+
+  public CaseInsensitiveHeaders getAllHeaders() {
+    // make a copy to avoid any modifications to contained headers
+    CaseInsensitiveHeaders result = new CaseInsensitiveHeaders();
+    result.addAll(headers);
+    return result;
+  }
+
+  public String getToken() {
+    return token;
+  }
+
+  public String getTenant() {
+    return tenant;
+  }
+
+  public String getHost() {
+    return host;
+  }
+
+  public int getPort() {
+    return port;
+  }
+
+  @Override
+  public String toString() {
+    return new ToStringBuilder(this)
+      .append("host", host)
+      .append("port", port)
+      .append("tenant", tenant)
+      .append("token", token)
+      .append("headers", headers)
+      .build();
+  }
+}

--- a/src/main/java/org/folio/util/exc/ExceptionHandlers.java
+++ b/src/main/java/org/folio/util/exc/ExceptionHandlers.java
@@ -2,8 +2,6 @@ package org.folio.util.exc;
 
 import static org.folio.util.pf.PartialFunctions.as;
 
-import java.util.function.Function;
-
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.core.MediaType;
@@ -12,10 +10,12 @@ import javax.ws.rs.core.Response;
 import io.vertx.core.Future;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpStatus;
 
 import org.folio.rest.tools.utils.ValidationHelper;
 import org.folio.util.pf.PartialFunction;
+import org.folio.util.pf.PartialFunctions;
 
 public class ExceptionHandlers {
 
@@ -36,25 +36,23 @@ public class ExceptionHandlers {
     return as(t -> true, ExceptionHandlers::toGeneral);
   }
 
-  public static Function<Throwable, Response> logged(PartialFunction<Throwable, Response> pf) {
-    return throwable -> {
-      LOGGER.error("Execution failed with: " + throwable.getMessage(), throwable);
-      return pf.apply(throwable);
-    };
+  public static PartialFunction<Throwable, Response> logged(PartialFunction<Throwable, Response> pf) {
+    return PartialFunctions.logged(pf, t -> LOGGER.error("Execution failed with: " + t.getMessage(), t));
+  }
+
+  private static Response status(int status, String msg) {
+    return Response.status(status)
+      .type(MediaType.TEXT_PLAIN)
+      .entity(StringUtils.defaultString(msg))
+      .build();
   }
 
   private static Response toBadRequest(Throwable t) {
-    return Response.status(HttpStatus.SC_BAD_REQUEST)
-      .type(MediaType.TEXT_PLAIN)
-      .entity(t.getMessage())
-      .build();
+    return status(HttpStatus.SC_BAD_REQUEST, t.getMessage());
   }
 
   private static Response toNotFound(Throwable t) {
-    return Response.status(HttpStatus.SC_NOT_FOUND)
-      .type(MediaType.TEXT_PLAIN)
-      .entity(t.getMessage())
-      .build();
+    return status(HttpStatus.SC_NOT_FOUND, t.getMessage());
   }
 
   private static Response toGeneral(Throwable t) {
@@ -64,10 +62,8 @@ public class ExceptionHandlers {
     if (validationFuture.succeeded()) {
       return validationFuture.result();
     } else {
-      return Response.status(HttpStatus.SC_INTERNAL_SERVER_ERROR)
-        .type(MediaType.TEXT_PLAIN)
-        .entity(Response.Status.INTERNAL_SERVER_ERROR.getReasonPhrase())
-        .build();
+      return status(HttpStatus.SC_INTERNAL_SERVER_ERROR, Response.Status.INTERNAL_SERVER_ERROR.getReasonPhrase());
     }
   }
+
 }

--- a/src/main/java/org/folio/util/exc/ExceptionHandlers.java
+++ b/src/main/java/org/folio/util/exc/ExceptionHandlers.java
@@ -1,6 +1,6 @@
 package org.folio.util.exc;
 
-import static org.folio.util.pf.PartialFunctions.as;
+import static org.folio.util.pf.PartialFunctions.pf;
 
 import java.util.function.Predicate;
 
@@ -34,18 +34,18 @@ public class ExceptionHandlers {
     //    t -> t instanceof BadRequestException || t instanceof CQL2PgJSONException
     //
     // the below is to show how predicates that potentially have complex logic can be combined
-    return as(instanceOf(BadRequestException.class)
+    return pf(instanceOf(BadRequestException.class)
                 .or(instanceOf(CQLQueryValidationException.class))
                 .or(instanceOf(CQL2PgJSONException.class)),
               ExceptionHandlers::toBadRequest);
   }
 
   public static PartialFunction<Throwable, Response> notFoundHandler() {
-    return as(NotFoundException.class::isInstance, ExceptionHandlers::toNotFound);
+    return pf(NotFoundException.class::isInstance, ExceptionHandlers::toNotFound);
   }
 
   public static PartialFunction<Throwable, Response> generalHandler() {
-    return as(t -> true, ExceptionHandlers::toGeneral);
+    return pf(t -> true, ExceptionHandlers::toGeneral);
   }
 
   public static PartialFunction<Throwable, Response> logged(PartialFunction<Throwable, Response> pf) {

--- a/src/main/java/org/folio/util/exc/ExceptionHandlers.java
+++ b/src/main/java/org/folio/util/exc/ExceptionHandlers.java
@@ -1,0 +1,73 @@
+package org.folio.util.exc;
+
+import static org.folio.util.pf.PartialFunctions.as;
+
+import java.util.function.Function;
+
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import io.vertx.core.Future;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import org.apache.http.HttpStatus;
+
+import org.folio.rest.tools.utils.ValidationHelper;
+import org.folio.util.pf.PartialFunction;
+
+public class ExceptionHandlers {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ExceptionHandlers.class);
+
+  private ExceptionHandlers() {
+  }
+
+  public static PartialFunction<Throwable, Response> badRequestHandler() {
+    return as(BadRequestException.class::isInstance, ExceptionHandlers::toBadRequest);
+  }
+
+  public static PartialFunction<Throwable, Response> notFoundHandler() {
+    return as(NotFoundException.class::isInstance, ExceptionHandlers::toNotFound);
+  }
+
+  public static PartialFunction<Throwable, Response> generalHandler() {
+    return as(t -> true, ExceptionHandlers::toGeneral);
+  }
+
+  public static Function<Throwable, Response> logged(PartialFunction<Throwable, Response> pf) {
+    return throwable -> {
+      LOGGER.error("Execution failed with: " + throwable.getMessage(), throwable);
+      return pf.apply(throwable);
+    };
+  }
+
+  private static Response toBadRequest(Throwable t) {
+    return Response.status(HttpStatus.SC_BAD_REQUEST)
+      .type(MediaType.TEXT_PLAIN)
+      .entity(t.getMessage())
+      .build();
+  }
+
+  private static Response toNotFound(Throwable t) {
+    return Response.status(HttpStatus.SC_NOT_FOUND)
+      .type(MediaType.TEXT_PLAIN)
+      .entity(t.getMessage())
+      .build();
+  }
+
+  private static Response toGeneral(Throwable t) {
+    Future<Response> validationFuture = Future.future();
+    ValidationHelper.handleError(t, validationFuture);
+
+    if (validationFuture.succeeded()) {
+      return validationFuture.result();
+    } else {
+      return Response.status(HttpStatus.SC_INTERNAL_SERVER_ERROR)
+        .type(MediaType.TEXT_PLAIN)
+        .entity(Response.Status.INTERNAL_SERVER_ERROR.getReasonPhrase())
+        .build();
+    }
+  }
+}

--- a/src/main/java/org/folio/util/exc/Exceptions.java
+++ b/src/main/java/org/folio/util/exc/Exceptions.java
@@ -1,0 +1,21 @@
+package org.folio.util.exc;
+
+import static java.lang.String.format;
+
+import javax.ws.rs.NotFoundException;
+
+public class Exceptions {
+
+  private static final String NOT_FOUND_MSG = "%s not found by id: %s";
+
+  private Exceptions() {
+  }
+
+  public static NotFoundException notFound(String entity, String id) {
+    return new NotFoundException(format(NOT_FOUND_MSG, entity, id));
+  }
+
+  public static NotFoundException notFound(Class<?> entityClass, String id) {
+    return notFound(entityClass.getSimpleName(), id);
+  }
+}

--- a/src/main/java/org/folio/util/pf/AndThen.java
+++ b/src/main/java/org/folio/util/pf/AndThen.java
@@ -2,7 +2,7 @@ package org.folio.util.pf;
 
 import java.util.function.Function;
 
-class AndThen<T, R, V> implements PartialFunction<T, V> {
+final class AndThen<T, R, V> implements PartialFunction<T, V> {
 
   private PartialFunction<T, R> pf;
   private Function<? super R, ? extends V> after;

--- a/src/main/java/org/folio/util/pf/AndThen.java
+++ b/src/main/java/org/folio/util/pf/AndThen.java
@@ -1,0 +1,26 @@
+package org.folio.util.pf;
+
+import java.util.function.Function;
+
+class AndThen<T, R, V> implements PartialFunction<T, V> {
+
+  private PartialFunction<T, R> pf;
+  private Function<? super R, ? extends V> after;
+
+
+  AndThen(PartialFunction<T, R> pf, Function<? super R, ? extends V> after) {
+    this.pf = pf;
+    this.after = after;
+  }
+
+  @Override
+  public boolean isDefinedAt(T t) {
+    return pf.isDefinedAt(t);
+  }
+
+  @Override
+  public V applySuccessfully(T t) {
+    return after.apply(pf.apply(t));
+  }
+
+}

--- a/src/main/java/org/folio/util/pf/Empty.java
+++ b/src/main/java/org/folio/util/pf/Empty.java
@@ -1,6 +1,6 @@
 package org.folio.util.pf;
 
-class Empty<T, R> implements PartialFunction<T, R> {
+final class Empty<T, R> implements PartialFunction<T, R> {
 
   @Override
   public R apply(T t) {

--- a/src/main/java/org/folio/util/pf/Empty.java
+++ b/src/main/java/org/folio/util/pf/Empty.java
@@ -1,0 +1,19 @@
+package org.folio.util.pf;
+
+class Empty<T, R> implements PartialFunction<T, R> {
+
+  @Override
+  public R apply(T t) {
+    throw new NotDefinedException(t);
+  }
+
+  @Override
+  public boolean isDefinedAt(T t) {
+    return false;
+  }
+
+  @Override
+  public R applySuccessfully(T t) {
+    return null;
+  }
+}

--- a/src/main/java/org/folio/util/pf/Lifted.java
+++ b/src/main/java/org/folio/util/pf/Lifted.java
@@ -1,0 +1,18 @@
+package org.folio.util.pf;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+class Lifted<T, R> implements Function<T, Optional<R>> {
+
+  private PartialFunction<T, R> pf;
+
+  Lifted(PartialFunction<T, R> pf) {
+  }
+
+  @Override
+  public Optional<R> apply(T t) {
+    return Optional.ofNullable(pf.applyOrElse(t, t1 -> null));
+  }
+
+}

--- a/src/main/java/org/folio/util/pf/LogHandler.java
+++ b/src/main/java/org/folio/util/pf/LogHandler.java
@@ -1,0 +1,8 @@
+package org.folio.util.pf;
+
+@FunctionalInterface
+public interface LogHandler<T> {
+
+  void log(T t);
+
+}

--- a/src/main/java/org/folio/util/pf/LoggedApplication.java
+++ b/src/main/java/org/folio/util/pf/LoggedApplication.java
@@ -1,0 +1,30 @@
+package org.folio.util.pf;
+
+final class LoggedApplication<T, R> implements PartialFunction<T, R> {
+
+  private PartialFunction<T, R> pf;
+  private LogHandler<? super T> logHandler;
+
+
+  LoggedApplication(PartialFunction<T, R> pf, LogHandler<? super T> logHandler) {
+    this.pf = pf;
+    this.logHandler = logHandler;
+  }
+
+  @Override
+  public R apply(T t) {
+    logHandler.log(t);
+    return pf.apply(t);
+  }
+
+  @Override
+  public boolean isDefinedAt(T t) {
+    return pf.isDefinedAt(t);
+  }
+
+  @Override
+  public R applySuccessfully(T t) {
+    return pf.applySuccessfully(t);
+  }
+
+}

--- a/src/main/java/org/folio/util/pf/NotDefinedException.java
+++ b/src/main/java/org/folio/util/pf/NotDefinedException.java
@@ -1,0 +1,9 @@
+package org.folio.util.pf;
+
+public class NotDefinedException extends RuntimeException {
+
+  public NotDefinedException(Object arg) {
+    super("Not defined for: " + arg);
+  }
+
+}

--- a/src/main/java/org/folio/util/pf/OrElse.java
+++ b/src/main/java/org/folio/util/pf/OrElse.java
@@ -1,0 +1,24 @@
+package org.folio.util.pf;
+
+class OrElse<T, R> implements PartialFunction<T, R> {
+
+  private PartialFunction<T, R> f1;
+  private PartialFunction<T, R> f2;
+
+
+  OrElse(PartialFunction<T, R> f1, PartialFunction<T, R> f2) {
+    this.f1 = f1;
+    this.f2 = f2;
+  }
+
+  @Override
+  public boolean isDefinedAt(T t) {
+    return f1.isDefinedAt(t) || f2.isDefinedAt(t);
+  }
+
+  @Override
+  public R applySuccessfully(T t) {
+    return f1.isDefinedAt(t) ? f1.apply(t) : f2.apply(t);
+  }
+
+}

--- a/src/main/java/org/folio/util/pf/OrElse.java
+++ b/src/main/java/org/folio/util/pf/OrElse.java
@@ -1,6 +1,6 @@
 package org.folio.util.pf;
 
-class OrElse<T, R> implements PartialFunction<T, R> {
+final class OrElse<T, R> implements PartialFunction<T, R> {
 
   private PartialFunction<T, R> f1;
   private PartialFunction<T, R> f2;

--- a/src/main/java/org/folio/util/pf/PartialFunction.java
+++ b/src/main/java/org/folio/util/pf/PartialFunction.java
@@ -1,0 +1,37 @@
+package org.folio.util.pf;
+
+import java.util.Objects;
+import java.util.function.Function;
+
+public interface PartialFunction<T, R> extends Function<T, R> {
+
+  @Override
+  default R apply(T t) {
+    return applyOrElse(t, PartialFunctions.empty());
+  }
+
+  default R applyOrElse(T t, Function<? super T, ? extends R> otherwise) {
+    Objects.requireNonNull(otherwise);
+    return isDefinedAt(t) ? applySuccessfully(t) : otherwise.apply(t);
+  }
+
+  boolean isDefinedAt(T t);
+
+  /**
+   * Important:
+   * The method shouldn't be called directly. It is more of internal one.
+   * Use {@link #apply(Object)} or {@link #applyOrElse(Object, Function)}
+   */
+  R applySuccessfully(T t);
+
+  default PartialFunction<T, R> orElse(PartialFunction<T, R> fallback) {
+    Objects.requireNonNull(fallback);
+    return PartialFunctions.orElse(this, fallback);
+  }
+
+  @Override
+  default <V> PartialFunction<T, V> andThen(Function<? super R, ? extends V> after) {
+    Objects.requireNonNull(after);
+    return PartialFunctions.andThen(this, after);
+  }
+}

--- a/src/main/java/org/folio/util/pf/PartialFunction.java
+++ b/src/main/java/org/folio/util/pf/PartialFunction.java
@@ -1,6 +1,7 @@
 package org.folio.util.pf;
 
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Function;
 
 /**
@@ -40,5 +41,9 @@ public interface PartialFunction<T, R> extends Function<T, R> {
   default <V> PartialFunction<T, V> andThen(Function<? super R, ? extends V> after) {
     Objects.requireNonNull(after);
     return PartialFunctions.andThen(this, after);
+  }
+
+  default Function<T, Optional<R>> lift() {
+    return PartialFunctions.lift(this);
   }
 }

--- a/src/main/java/org/folio/util/pf/PartialFunction.java
+++ b/src/main/java/org/folio/util/pf/PartialFunction.java
@@ -3,6 +3,13 @@ package org.folio.util.pf;
 import java.util.Objects;
 import java.util.function.Function;
 
+/**
+ * Inspired by <a href="https://www.scala-lang.org/api/current/scala/PartialFunction.html">Scala implementation</a>
+ * of partial functions.
+ * 
+ * @param <T> the type of the input to the function
+ * @param <R> the type of the result of the function
+ */
 public interface PartialFunction<T, R> extends Function<T, R> {
 
   @Override

--- a/src/main/java/org/folio/util/pf/PartialFunctionImpl.java
+++ b/src/main/java/org/folio/util/pf/PartialFunctionImpl.java
@@ -6,10 +6,10 @@ import java.util.function.Predicate;
 class PartialFunctionImpl<T, R> implements PartialFunction<T, R> {
 
   private Predicate<? super T> isDefinedAt;
-  private Function<T, R> function;
+  private Function<? super T, ? extends R> function;
 
 
-  PartialFunctionImpl(Predicate<? super T> isDefinedAt, Function<T, R> function) {
+  PartialFunctionImpl(Predicate<? super T> isDefinedAt, Function<? super T, ? extends R> function) {
     this.function = function;
     this.isDefinedAt = isDefinedAt;
   }

--- a/src/main/java/org/folio/util/pf/PartialFunctionImpl.java
+++ b/src/main/java/org/folio/util/pf/PartialFunctionImpl.java
@@ -1,0 +1,26 @@
+package org.folio.util.pf;
+
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+class PartialFunctionImpl<T, R> implements PartialFunction<T, R> {
+
+  private Predicate<? super T> isDefinedAt;
+  private Function<T, R> function;
+
+
+  PartialFunctionImpl(Predicate<? super T> isDefinedAt, Function<T, R> function) {
+    this.function = function;
+    this.isDefinedAt = isDefinedAt;
+  }
+
+  @Override
+  public boolean isDefinedAt(T t) {
+    return isDefinedAt.test(t);
+  }
+
+  @Override
+  public R applySuccessfully(T t) {
+    return function.apply(t);
+  }
+}

--- a/src/main/java/org/folio/util/pf/PartialFunctions.java
+++ b/src/main/java/org/folio/util/pf/PartialFunctions.java
@@ -1,0 +1,26 @@
+package org.folio.util.pf;
+
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+public class PartialFunctions {
+
+  private static final PartialFunction EMPTY = new Empty<>();
+
+  public static <T, R> PartialFunction<T, R> as(Predicate<? super T> isDefinedAt, Function<T, R> function) {
+    return new PartialFunctionImpl<>(isDefinedAt, function);
+  }
+
+  @SuppressWarnings("unchecked")
+  public static <T, R> PartialFunction<T, R> empty() {
+    return (PartialFunction<T, R>) EMPTY;
+  }
+
+  public static <T, R> PartialFunction<T, R> orElse(PartialFunction<T, R> f1, PartialFunction<T, R> f2) {
+    return new OrElse<>(f1, f2);
+  }
+
+  public static <T, R, V> PartialFunction<T, V> andThen(PartialFunction<T, R> pf, Function<? super R, ? extends V> after) {
+    return new AndThen<>(pf, after);
+  }
+}

--- a/src/main/java/org/folio/util/pf/PartialFunctions.java
+++ b/src/main/java/org/folio/util/pf/PartialFunctions.java
@@ -1,13 +1,17 @@
 package org.folio.util.pf;
 
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
-public class PartialFunctions {
+public final class PartialFunctions {
 
   private static final PartialFunction EMPTY = new Empty<>();
 
-  public static <T, R> PartialFunction<T, R> as(Predicate<? super T> isDefinedAt,
+  private PartialFunctions() {
+  }
+
+  public static <T, R> PartialFunction<T, R> pf(Predicate<? super T> isDefinedAt,
                                                 Function<? super T, ? extends R> function) {
     return new PartialFunctionImpl<>(isDefinedAt, function);
   }
@@ -27,5 +31,9 @@ public class PartialFunctions {
 
   public static <T, R> PartialFunction<T, R> logged(PartialFunction<T, R> pf, LogHandler<? super T> logger) {
     return new LoggedApplication<>(pf, logger);
+  }
+
+  public static <T, R> Function<T, Optional<R>> lift(PartialFunction<T, R> pf) {
+    return new Lifted<>(pf);
   }
 }

--- a/src/main/java/org/folio/util/pf/PartialFunctions.java
+++ b/src/main/java/org/folio/util/pf/PartialFunctions.java
@@ -7,7 +7,8 @@ public class PartialFunctions {
 
   private static final PartialFunction EMPTY = new Empty<>();
 
-  public static <T, R> PartialFunction<T, R> as(Predicate<? super T> isDefinedAt, Function<T, R> function) {
+  public static <T, R> PartialFunction<T, R> as(Predicate<? super T> isDefinedAt,
+                                                Function<? super T, ? extends R> function) {
     return new PartialFunctionImpl<>(isDefinedAt, function);
   }
 
@@ -22,5 +23,9 @@ public class PartialFunctions {
 
   public static <T, R, V> PartialFunction<T, V> andThen(PartialFunction<T, R> pf, Function<? super R, ? extends V> after) {
     return new AndThen<>(pf, after);
+  }
+
+  public static <T, R> PartialFunction<T, R> logged(PartialFunction<T, R> pf, LogHandler<? super T> logger) {
+    return new LoggedApplication<>(pf, logger);
   }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+note.configuration.module=NOTES
+note.types.number.limit.default=25

--- a/src/test/java/org/folio/config/ModConfigurationTest.java
+++ b/src/test/java/org/folio/config/ModConfigurationTest.java
@@ -1,0 +1,209 @@
+package org.folio.config;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import static org.folio.util.TestUtil.mockGet;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.github.tomakehurst.wiremock.common.Slf4jNotifier;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.github.tomakehurst.wiremock.matching.RegexPattern;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.apache.http.HttpStatus;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
+import org.junit.runner.RunWith;
+
+import org.folio.okapi.common.XOkapiHeaders;
+import org.folio.util.OkapiParams;
+
+@RunWith(VertxUnitRunner.class)
+public class ModConfigurationTest {
+
+  private static final String STUB_TENANT = "testlib";
+  private static final String STUB_TOKEN = "TEST_OKAPI_TOKEN";
+  private static final String HOST = "http://127.0.0.1";
+
+  private static final String CONFIG_MODULE = "NOTES";
+  private static final String CONFIG_PROP_CODE = "note.types.number.limit";
+  private static final RegexPattern CONFIG_NOTE_TYPE_LIMIT_URL_PATTERN =
+    new RegexPattern("/configurations/entries.*");
+
+  private static final Logger logger = LoggerFactory.getLogger(ModConfigurationTest.class);
+
+  @Rule
+  public TestRule watcher = new TestWatcher() {
+
+    @Override
+    protected void starting(Description description) {
+      logger.info("********** Running test method: {}.{} ********** ", description.getClassName(),
+        description.getMethodName());
+    }
+
+  };
+
+  @Rule
+  public WireMockRule mockServer = new WireMockRule(
+    WireMockConfiguration.wireMockConfig()
+      .dynamicPort()
+      .notifier(new Slf4jNotifier(true)));
+
+  private OkapiParams okapiParams;
+  private ModConfiguration configuration;
+
+
+  @Before
+  public void setUp() {
+    Map<String, String> headers = new HashMap<>();
+    headers.put(XOkapiHeaders.TENANT, STUB_TENANT);
+    headers.put(XOkapiHeaders.TOKEN, STUB_TOKEN);
+    headers.put(XOkapiHeaders.URL, HOST + ":" + mockServer.port());
+
+    okapiParams = new OkapiParams(headers);
+    configuration = new ModConfiguration(CONFIG_MODULE);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void failIfModuleNotProvidedToConstructor() {
+    new ModConfiguration("");
+  }
+
+  @Test
+  public void shouldReturnPropAsString(TestContext context) throws IOException, URISyntaxException {
+    mockGet(CONFIG_NOTE_TYPE_LIMIT_URL_PATTERN, "responses/configuration/get-note-type-limit-5-response.json");
+
+    Handler<AsyncResult<String>> verify = context.asyncAssertSuccess(result -> {
+      assertNotNull(result);
+      assertEquals("5", result);
+    });
+
+    configuration.getString(CONFIG_PROP_CODE, okapiParams).setHandler(verify);
+  }
+
+  @Test
+  public void shouldReturnPropAsInt(TestContext context) throws IOException, URISyntaxException {
+    mockGet(CONFIG_NOTE_TYPE_LIMIT_URL_PATTERN, "responses/configuration/get-note-type-limit-5-response.json");
+
+    Handler<AsyncResult<Integer>> verify = context.asyncAssertSuccess(result -> {
+      assertNotNull(result);
+      assertEquals(5, result.intValue());
+    });
+
+    configuration.getInt(CONFIG_PROP_CODE, okapiParams).setHandler(verify);
+  }
+
+  @Test
+  public void shouldReturnPropAsLong(TestContext context) throws IOException, URISyntaxException {
+    mockGet(CONFIG_NOTE_TYPE_LIMIT_URL_PATTERN, "responses/configuration/get-note-type-limit-5-response.json");
+
+    Handler<AsyncResult<Long>> verify = context.asyncAssertSuccess(result -> {
+      assertNotNull(result);
+      assertEquals(5L, result.longValue());
+    });
+
+    configuration.getLong(CONFIG_PROP_CODE, okapiParams).setHandler(verify);
+  }
+
+  @Test
+  public void shouldReturnPropAsDouble(TestContext context) throws IOException, URISyntaxException {
+    mockGet(CONFIG_NOTE_TYPE_LIMIT_URL_PATTERN, "responses/configuration/get-note-type-limit-5-response.json");
+
+    Handler<AsyncResult<Double>> verify = context.asyncAssertSuccess(result -> {
+      assertNotNull(result);
+      assertEquals(5d, result, 0);
+    });
+
+    configuration.getDouble(CONFIG_PROP_CODE, okapiParams).setHandler(verify);
+  }
+
+  @Test
+  public void shouldReturnDefaultInCaseOfFailure(TestContext context) {
+    mockGet(CONFIG_NOTE_TYPE_LIMIT_URL_PATTERN, HttpStatus.SC_BAD_REQUEST);
+
+    Handler<AsyncResult<String>> verify = context.asyncAssertSuccess(result -> {
+      assertNotNull(result);
+      assertEquals("10", result);
+    });
+
+    configuration.getString(CONFIG_PROP_CODE, "10", okapiParams).setHandler(verify);
+  }
+
+  @Test
+  public void failIfPropNotFound(TestContext context) throws IOException, URISyntaxException {
+    mockGet(CONFIG_NOTE_TYPE_LIMIT_URL_PATTERN, "responses/configuration/get-note-type-limit-empty-response.json");
+
+    Handler<AsyncResult<String>> verify = context.asyncAssertFailure(t -> {
+      assertTrue(t instanceof PropertyNotFoundException);
+      assertEquals(CONFIG_PROP_CODE, ((PropertyNotFoundException) t).getPropertyCode());
+    });
+
+    configuration.getString(CONFIG_PROP_CODE, okapiParams).setHandler(verify);
+  }
+
+  @Test
+  public void failIfPropDisabled(TestContext context) throws IOException, URISyntaxException {
+    mockGet(CONFIG_NOTE_TYPE_LIMIT_URL_PATTERN, "responses/configuration/get-note-type-limit-disabled-response.json");
+
+    Handler<AsyncResult<String>> verify = context.asyncAssertFailure(t -> {
+      assertTrue(t instanceof PropertyNotFoundException);
+      assertEquals(CONFIG_PROP_CODE, ((PropertyNotFoundException) t).getPropertyCode());
+    });
+
+    configuration.getString(CONFIG_PROP_CODE, okapiParams).setHandler(verify);
+  }
+
+  @Test
+  public void failIfResponseNotOk(TestContext context) {
+    mockGet(CONFIG_NOTE_TYPE_LIMIT_URL_PATTERN, HttpStatus.SC_BAD_REQUEST);
+
+    Handler<AsyncResult<String>> verify = context.asyncAssertFailure(t -> {
+      assertTrue(t instanceof ConfigurationException);
+      assertThat(t.getMessage(), containsString(String.valueOf(HttpStatus.SC_BAD_REQUEST)));
+    });
+
+    configuration.getString(CONFIG_PROP_CODE, okapiParams).setHandler(verify);
+  }
+
+  @Test
+  public void failIfNoValueInConfig(TestContext context) throws IOException, URISyntaxException {
+    mockGet(CONFIG_NOTE_TYPE_LIMIT_URL_PATTERN, "responses/configuration/get-note-type-limit-no-value-response.json");
+
+    Handler<AsyncResult<String>> verify = context.asyncAssertFailure(t -> {
+      assertTrue(t instanceof ValueNotDefinedException);
+      assertEquals(CONFIG_PROP_CODE, ((ValueNotDefinedException) t).getPropertyCode());
+    });
+
+    configuration.getString(CONFIG_PROP_CODE, okapiParams).setHandler(verify);
+  }
+
+  @Test
+  public void failIfSeveralPropsPresent(TestContext context) throws IOException, URISyntaxException {
+    mockGet(CONFIG_NOTE_TYPE_LIMIT_URL_PATTERN, "responses/configuration/get-note-type-limit-not-unique-response.json");
+
+    Handler<AsyncResult<String>> verify = context.asyncAssertFailure(t -> {
+      assertTrue(t instanceof PropertyException);
+      assertEquals(CONFIG_PROP_CODE, ((PropertyException) t).getPropertyCode());
+      assertThat(t.getMessage(), containsString("more than one configuration properties found"));
+    });
+
+    configuration.getString(CONFIG_PROP_CODE, okapiParams).setHandler(verify);
+  }
+}

--- a/src/test/java/org/folio/rest/impl/NoteTypesImplTest.java
+++ b/src/test/java/org/folio/rest/impl/NoteTypesImplTest.java
@@ -59,7 +59,7 @@ import org.folio.spring.SpringContextUtil;
 public class NoteTypesImplTest extends TestBase {
 
   private static final int NOTE_TOTAL = 10;
-  private static final String STUB_NOTE_TYPE_ID = "2cf21797-d25b-46dc-8427-1759d1db2057";
+  private static final String STUB_NOTE_TYPE_ID = "13f21797-d25b-46dc-8427-1759d1db2057";
   private static final String NOT_EXISTING_STUB_ID = "9798274e-ce9d-46ab-aa28-00ca9cf4698a";
   
   private static final String NOTE_TYPES_ENDPOINT = "/note-types";

--- a/src/test/java/org/folio/rest/impl/NoteTypesImplTest.java
+++ b/src/test/java/org/folio/rest/impl/NoteTypesImplTest.java
@@ -1,18 +1,11 @@
 package org.folio.rest.impl;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.get;
-import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
-import static org.apache.http.HttpStatus.SC_BAD_REQUEST;
-import static org.apache.http.HttpStatus.SC_NOT_FOUND;
-import static org.apache.http.HttpStatus.SC_UNPROCESSABLE_ENTITY;
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
 import static org.jeasy.random.FieldPredicates.named;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 
 import static org.folio.util.TestUtil.readFile;
 import static org.folio.util.TestUtil.toJson;
@@ -20,38 +13,31 @@ import static org.folio.util.TestUtil.toJson;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.List;
-import java.util.Objects;
 import java.util.UUID;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
-import com.github.tomakehurst.wiremock.matching.EqualToPattern;
-import com.github.tomakehurst.wiremock.matching.UrlPathPattern;
 import io.restassured.RestAssured;
-import io.restassured.http.Header;
 import io.restassured.response.Response;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
-import org.hamcrest.MatcherAssert;
+import org.apache.http.HttpStatus;
 import org.jeasy.random.EasyRandom;
 import org.jeasy.random.EasyRandomParameters;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import org.folio.okapi.common.XOkapiHeaders;
 import org.folio.rest.TestBase;
-import org.folio.rest.jaxrs.model.Metadata;
 import org.folio.rest.jaxrs.model.NoteType;
 import org.folio.rest.jaxrs.model.NoteTypeUsage;
 import org.folio.rest.persist.PostgresClient;
+import org.folio.spring.SpringContextUtil;
 
 @RunWith(VertxUnitRunner.class)
 public class NoteTypesImplTest extends TestBase {
 
   private static final int NOTE_TOTAL = 10;
   private static final String STUB_NOTE_TYPE_ID = "2cf21797-d25b-46dc-8427-1759d1db2057";
-  private static final Header USER9 = new Header(XOkapiHeaders.USER_ID, "99999999-9999-4999-9999-999999999999");
-  private static final Header USER8 = new Header(XOkapiHeaders.USER_ID, "88888888-8888-4888-8888-888888888888");
   private static final String NOT_EXISTING_STUB_ID = "9798274e-ce9d-46ab-aa28-00ca9cf4698a";
   private static final String NOTE_TYPES_ENDPOINT = "/note-types";
   private static final String TOTAL_RECORDS = "totalRecords";
@@ -60,11 +46,14 @@ public class NoteTypesImplTest extends TestBase {
   private static final int MAX_LIMIT_AND_OFFSET = 2147483647;
   private static final int NULL_LIMIT_AND_OFFSET = 0;
 
-  private ObjectMapper mapper = new ObjectMapper();
+  private ObjectMapper mapper;
   private EasyRandom noteTypeRandom;
 
 
-  public NoteTypesImplTest() {
+  @Before
+  public void setUp() {
+    SpringContextUtil.autowireDependenciesFromFirstContext(this, vertx);
+
     // configure random object generator for NoteType
     EasyRandomParameters params = new EasyRandomParameters()
       .randomize(named("id"), () -> UUID.randomUUID().toString())
@@ -72,30 +61,8 @@ public class NoteTypesImplTest extends TestBase {
       .excludeField(named("metadata"));
 
     noteTypeRandom = new EasyRandom(params);
-  }
 
-  @Before
-  public void set() throws IOException, URISyntaxException {
-    stubFor(
-      get(new UrlPathPattern(new EqualToPattern("/users/99999999-9999-4999-9999-999999999999"), false))
-        .willReturn(new ResponseDefinitionBuilder()
-          .withStatus(200)
-          .withBody(readFile("users/mock_user.json"))
-        ));
-
-    stubFor(
-      get(new UrlPathPattern(new EqualToPattern("/users/88888888-8888-4888-8888-888888888888"), false))
-        .willReturn(new ResponseDefinitionBuilder()
-          .withStatus(200)
-          .withBody(readFile("users/mock_another_user.json"))
-        ));
-
-    stubFor(
-      get(new UrlPathPattern(new EqualToPattern("/users/33999999-9999-4999-9999-999999999933"), false))
-        .willReturn(new ResponseDefinitionBuilder()
-          .withStatus(200)
-          .withBody(readFile("users/mock_user_no_name.json"))
-        ));
+    mapper = new ObjectMapper();
   }
 
   @Test
@@ -118,7 +85,13 @@ public class NoteTypesImplTest extends TestBase {
 
       DBTestUtil.insertNoteType(vertx, STUB_NOTE_TYPE_ID, STUB_TENANT, stubNoteType);
 
-      Response response = getWithOk(NOTE_TYPES_ENDPOINT).response();
+      Response response = RestAssured.given()
+        .spec(getRequestSpecification())
+        .when()
+        .get(NOTE_TYPES_ENDPOINT)
+        .then()
+        .statusCode(200)
+        .extract().response();
 
       int totalRecords = response.path(TOTAL_RECORDS);
       List<NoteType> noteTypes = response.path(NOTE_TYPES);
@@ -139,7 +112,13 @@ public class NoteTypesImplTest extends TestBase {
       for (NoteType noteType : noteTypes) {
         DBTestUtil.insertNoteType(vertx, noteType.getId(), STUB_TENANT, mapper.writeValueAsString(noteType));
       }
-      Response response = getWithOk(NOTE_TYPES_ENDPOINT + "?limit=" + MAX_LIMIT_AND_OFFSET + "&offset=2").response();
+      Response response = RestAssured.given()
+        .spec(getRequestSpecification())
+        .when()
+        .get(NOTE_TYPES_ENDPOINT + "?limit=" + MAX_LIMIT_AND_OFFSET + "&offset=2")
+        .then()
+        .statusCode(200)
+        .extract().response();
 
       int totalRecords = response.path(TOTAL_RECORDS);
       List<NoteType> noteTypeList = response.path(NOTE_TYPES);
@@ -160,7 +139,13 @@ public class NoteTypesImplTest extends TestBase {
       for (NoteType noteType : noteTypes) {
         DBTestUtil.insertNoteType(vertx, noteType.getId(), STUB_TENANT, mapper.writeValueAsString(noteType));
       }
-      Response response = getWithOk(NOTE_TYPES_ENDPOINT + "?limit=" + MAX_LIMIT_AND_OFFSET).response();
+      Response response = RestAssured.given()
+        .spec(getRequestSpecification())
+        .when()
+        .get(NOTE_TYPES_ENDPOINT + "?limit=" + MAX_LIMIT_AND_OFFSET)
+        .then()
+        .statusCode(200)
+        .extract().response();
 
       int totalRecords = response.path(TOTAL_RECORDS);
       List<NoteType> noteTypeList = response.path(NOTE_TYPES);
@@ -181,7 +166,13 @@ public class NoteTypesImplTest extends TestBase {
       for (NoteType noteType : noteTypes) {
         DBTestUtil.insertNoteType(vertx, noteType.getId(), STUB_TENANT, mapper.writeValueAsString(noteType));
       }
-      Response response = getWithOk(NOTE_TYPES_ENDPOINT + "?offset=" + MAX_LIMIT_AND_OFFSET).response();
+      Response response = RestAssured.given()
+        .spec(getRequestSpecification())
+        .when()
+        .get(NOTE_TYPES_ENDPOINT + "?offset=" + MAX_LIMIT_AND_OFFSET)
+        .then()
+        .statusCode(200)
+        .extract().response();
 
       int totalRecords = response.path(TOTAL_RECORDS);
       List<NoteType> noteTypeList = response.path(NOTE_TYPES);
@@ -202,7 +193,13 @@ public class NoteTypesImplTest extends TestBase {
       for (NoteType noteType : noteTypes) {
         DBTestUtil.insertNoteType(vertx, noteType.getId(), STUB_TENANT, mapper.writeValueAsString(noteType));
       }
-      Response response = getWithOk(NOTE_TYPES_ENDPOINT + "?offset=" + NULL_LIMIT_AND_OFFSET).response();
+      Response response = RestAssured.given()
+        .spec(getRequestSpecification())
+        .when()
+        .get(NOTE_TYPES_ENDPOINT + "?offset=" + NULL_LIMIT_AND_OFFSET)
+        .then()
+        .statusCode(200)
+        .extract().response();
 
       int totalRecords = response.path(TOTAL_RECORDS);
       List<NoteType> noteTypeList = response.path(NOTE_TYPES);
@@ -223,7 +220,13 @@ public class NoteTypesImplTest extends TestBase {
       for (NoteType noteType : noteTypes) {
         DBTestUtil.insertNoteType(vertx, noteType.getId(), STUB_TENANT, mapper.writeValueAsString(noteType));
       }
-      Response response = getWithOk(NOTE_TYPES_ENDPOINT + "?limit=" + NULL_LIMIT_AND_OFFSET).response();
+      Response response = RestAssured.given()
+        .spec(getRequestSpecification())
+        .when()
+        .get(NOTE_TYPES_ENDPOINT + "?limit=" + NULL_LIMIT_AND_OFFSET)
+        .then()
+        .statusCode(200)
+        .extract().response();
 
       int totalRecords = response.path(TOTAL_RECORDS);
       List<NoteType> noteTypeList = response.path(NOTE_TYPES);
@@ -238,7 +241,13 @@ public class NoteTypesImplTest extends TestBase {
   @Test
   public void shouldReturn400WhenLimitInvalid() {
     try {
-      getWithStatus(NOTE_TYPES_ENDPOINT + "&limit=-1", SC_BAD_REQUEST);
+      RestAssured.given()
+        .spec(getRequestSpecification())
+        .when()
+        .get(NOTE_TYPES_ENDPOINT + "&limit=-1")
+        .then()
+        .statusCode(400)
+        .extract().asString();
     } finally {
       DBTestUtil.deleteFromTable(vertx, (PostgresClient.convertToPsqlStandard(STUB_TENANT) + "." + DBTestUtil.NOTE_TYPE_TABLE));
     }
@@ -247,7 +256,13 @@ public class NoteTypesImplTest extends TestBase {
   @Test
   public void shouldReturn400WhenOffsetInvalid() {
     try {
-      getWithStatus(NOTE_TYPES_ENDPOINT + "&offset=-1", SC_BAD_REQUEST);
+      RestAssured.given()
+        .spec(getRequestSpecification())
+        .when()
+        .get(NOTE_TYPES_ENDPOINT + "&offset=-1")
+        .then()
+        .statusCode(400)
+        .extract().asString();
     } finally {
       DBTestUtil.deleteFromTable(vertx, (PostgresClient.convertToPsqlStandard(STUB_TENANT) + "." + DBTestUtil.NOTE_TYPE_TABLE));
     }
@@ -262,7 +277,13 @@ public class NoteTypesImplTest extends TestBase {
       for (NoteType noteType : noteTypes) {
         DBTestUtil.insertNoteType(vertx, noteType.getId(), STUB_TENANT, mapper.writeValueAsString(noteType));
       }
-      Response response = getWithOk(NOTE_TYPES_ENDPOINT).response();
+      Response response = RestAssured.given()
+        .spec(getRequestSpecification())
+        .when()
+        .get(NOTE_TYPES_ENDPOINT)
+        .then()
+        .statusCode(200)
+        .extract().response();
 
       int totalRecords = response.path(TOTAL_RECORDS);
       List<NoteType> noteTypeList = response.path(NOTE_TYPES);
@@ -281,7 +302,13 @@ public class NoteTypesImplTest extends TestBase {
 
       DBTestUtil.insertNoteType(vertx, STUB_NOTE_TYPE_ID, STUB_TENANT, stubNoteType);
 
-      Response response = getWithOk(NOTE_TYPES_ENDPOINT + "?quer").response();
+      Response response = RestAssured.given()
+        .spec(getRequestSpecification())
+        .when()
+        .get(NOTE_TYPES_ENDPOINT + "?quer")
+        .then()
+        .statusCode(200)
+        .extract().response();
 
       int totalRecords = response.path(TOTAL_RECORDS);
       List<NoteType> noteTypes = response.path(NOTE_TYPES);
@@ -296,7 +323,13 @@ public class NoteTypesImplTest extends TestBase {
   @Test
   public void shouldReturn200WithEmptyNoteTypeCollection() {
     try {
-      Response response = getWithOk(NOTE_TYPES_ENDPOINT).response();
+      Response response = RestAssured.given()
+        .spec(getRequestSpecification())
+        .when()
+        .get(NOTE_TYPES_ENDPOINT)
+        .then()
+        .statusCode(200)
+        .extract().response();
 
       int totalRecords = response.path(TOTAL_RECORDS);
       List<NoteType> noteTypes = response.path(NOTE_TYPES);
@@ -315,7 +348,13 @@ public class NoteTypesImplTest extends TestBase {
 
       DBTestUtil.insertNoteType(vertx, STUB_NOTE_TYPE_ID, STUB_TENANT, stubNoteType);
 
-      getWithStatus(NOTE_TYPES_ENDPOINT + "?query=", SC_BAD_REQUEST);
+      RestAssured.given()
+        .spec(getRequestSpecification())
+        .when()
+        .get(NOTE_TYPES_ENDPOINT + "?query=")
+        .then()
+        .statusCode(400)
+        .extract().asString();
     } finally {
       DBTestUtil.deleteFromTable(vertx, (PostgresClient.convertToPsqlStandard(STUB_TENANT) + "." + DBTestUtil.NOTE_TYPE_TABLE));
     }
@@ -328,42 +367,32 @@ public class NoteTypesImplTest extends TestBase {
 
       DBTestUtil.insertNoteType(vertx, STUB_NOTE_TYPE_ID, STUB_TENANT, stubNoteType);
 
-      getWithStatus(NOTE_TYPES_ENDPOINT + "?limit=", SC_BAD_REQUEST);
+      RestAssured.given()
+        .spec(getRequestSpecification())
+        .when()
+        .get(NOTE_TYPES_ENDPOINT + "?limit=")
+        .then()
+        .statusCode(400)
+        .extract().asString();
     } finally {
       DBTestUtil.deleteFromTable(vertx, (PostgresClient.convertToPsqlStandard(STUB_TENANT) + "." + DBTestUtil.NOTE_TYPE_TABLE));
     }
   }
 
   @Test
-  public void shouldReturn404WhenInvalidNotExistingId() {
-    final String response = getWithStatus(NOTE_TYPES_ENDPOINT + "/" + NOT_EXISTING_STUB_ID, SC_NOT_FOUND).asString();
-    assertThat(response, equalTo("Not found"));
-  }
-
-  @Test
-  public void shouldReturn400WhenInvalidId() {
-    final String invalidStubId = "11111111-222-1111-2-111111111111";
-    getWithStatus(NOTE_TYPES_ENDPOINT + "/" + invalidStubId, SC_BAD_REQUEST).asString();
+  public void shouldReturn404WhenInvalidId() {
+    getWithStatus(NOTE_TYPES_ENDPOINT + "/" + NOT_EXISTING_STUB_ID, HttpStatus.SC_NOT_FOUND).asString();
   }
 
   @Test
   public void shouldUpdateNoteNameTypeOnPut() throws IOException, URISyntaxException {
     try {
-      postNoteTypeWithOk(readFile("post_note.json"), USER9);
+      DBTestUtil.insertNoteType(vertx, STUB_NOTE_TYPE_ID, STUB_TENANT, readFile("post_note.json"));
       NoteType updatedNoteType = mapper.readValue(readFile("put_note.json"), NoteType.class);
-
-      putWithOk(NOTE_TYPES_ENDPOINT + "/" + STUB_NOTE_TYPE_ID, mapper.writeValueAsString(updatedNoteType), USER8);
+      updateNoteType(updatedNoteType);
 
       NoteType loaded = loadSingleNote();
       assertEquals(updatedNoteType.getName(), loaded.getName());
-
-      final Metadata noteTypeMetadata = loaded.getMetadata();
-      assertEquals("99999999-9999-4999-9999-999999999999", noteTypeMetadata.getCreatedByUserId());
-      assertEquals("mockuser9", noteTypeMetadata.getCreatedByUsername());
-
-      assertEquals("88888888-8888-4888-8888-888888888888", noteTypeMetadata.getUpdatedByUserId());
-      assertEquals("m8", noteTypeMetadata.getUpdatedByUsername());
-
     } finally {
       DBTestUtil.deleteFromTable(vertx, (PostgresClient.convertToPsqlStandard(STUB_TENANT) + "." + DBTestUtil.NOTE_TYPE_TABLE));
     }
@@ -372,12 +401,11 @@ public class NoteTypesImplTest extends TestBase {
   @Test
   public void shouldNotSetNoteUsageOnPut() throws IOException, URISyntaxException {
     try {
+      DBTestUtil.insertNoteType(vertx, STUB_NOTE_TYPE_ID, STUB_TENANT, readFile("post_note.json"));
       NoteType updatedNoteType = mapper.readValue(readFile("put_note.json"), NoteType.class);
       updatedNoteType.withUsage(new NoteTypeUsage().withNoteTotal(NOTE_TOTAL));
 
-      postNoteTypeWithOk(toJson(updatedNoteType), USER8);
-
-      putWithOk(NOTE_TYPES_ENDPOINT + "/" + STUB_NOTE_TYPE_ID, mapper.writeValueAsString(updatedNoteType), USER8);
+      updateNoteType(updatedNoteType);
 
       NoteType loaded = loadSingleNote();
       assertNull(loaded.getUsage());
@@ -388,14 +416,19 @@ public class NoteTypesImplTest extends TestBase {
 
   @Test
   public void shouldReturn404OnPutWhenNoteNotFound() throws IOException, URISyntaxException {
-    putWithStatus(NOTE_TYPES_ENDPOINT + "/" + STUB_NOTE_TYPE_ID, readFile("put_note.json"),
-      SC_NOT_FOUND, USER9);
+    putWithStatus("note-types/" + STUB_NOTE_TYPE_ID, readFile("put_note.json"),
+      HttpStatus.SC_NOT_FOUND);
   }
 
   @Test
   public void shouldReturn400OnPutWhenRequestIsInvalid() {
-    putWithStatus(NOTE_TYPES_ENDPOINT + "/" + STUB_NOTE_TYPE_ID, "{\"name\":null}",
-      SC_UNPROCESSABLE_ENTITY, USER9);
+    putWithStatus("note-types/" + STUB_NOTE_TYPE_ID, "{\"name\":null}",
+      HttpStatus.SC_UNPROCESSABLE_ENTITY);
+  }
+
+  private void updateNoteType(NoteType updatedNoteType) throws JsonProcessingException {
+    putWithStatus("note-types/" + STUB_NOTE_TYPE_ID, mapper.writeValueAsString(updatedNoteType),
+      HttpStatus.SC_NO_CONTENT);
   }
 
   @Test
@@ -403,7 +436,8 @@ public class NoteTypesImplTest extends TestBase {
     try {
       NoteType input = nextRandomNoteType();
 
-      NoteType response = postNoteTypeWithOk(toJson(input), USER9).as(NoteType.class);
+      NoteType response = postWithStatus("note-types/", toJson(input), HttpStatus.SC_CREATED)
+        .as(NoteType.class);
 
       assertNotNull(response);
       assertEquals(input.getId(), response.getId());
@@ -412,25 +446,6 @@ public class NoteTypesImplTest extends TestBase {
       NoteType loaded = loadSingleNote();
       assertEquals(input.getId(), loaded.getId());
       assertEquals(input.getName(), loaded.getName());
-
-      final Metadata noteTypeMetadata = loaded.getMetadata();
-      assertEquals("mockuser9", noteTypeMetadata.getCreatedByUsername());
-      assertEquals("99999999-9999-4999-9999-999999999999", noteTypeMetadata.getCreatedByUserId());
-      assertTrue(Objects.nonNull(noteTypeMetadata.getCreatedDate()));
-      assertTrue(Objects.isNull(noteTypeMetadata.getUpdatedByUsername()));
-
-    } finally {
-      DBTestUtil.deleteAllNoteTypes(vertx);
-    }
-  }
-
-  @Test
-  public void shouldReturn400ErrorWhenAddingNoteWithExistingUUID() {
-    try {
-      NoteType input = nextRandomNoteType();
-      postNoteTypeWithOk(toJson(input), USER9);
-      String response = postWithStatus(NOTE_TYPES_ENDPOINT, toJson(input), SC_BAD_REQUEST, USER9).asString();
-      assertThat(response, containsString("Note type with specified UUID already exists"));
     } finally {
       DBTestUtil.deleteAllNoteTypes(vertx);
     }
@@ -438,7 +453,7 @@ public class NoteTypesImplTest extends TestBase {
 
   @Test
   public void shouldReturn422OnPostWhenRequestIsInvalid() {
-    postWithStatus(NOTE_TYPES_ENDPOINT, "{\"name\":null}", SC_UNPROCESSABLE_ENTITY, USER9);
+    postWithStatus("note-types/", "{\"name\":null}", HttpStatus.SC_UNPROCESSABLE_ENTITY);
   }
 
   @Test
@@ -448,7 +463,8 @@ public class NoteTypesImplTest extends TestBase {
       DBTestUtil.insertNoteType(vertx, existing.getId(), STUB_TENANT, toJson(existing));
 
       NoteType creating = new NoteType().withName(existing.getName());
-      String error = postWithStatus(NOTE_TYPES_ENDPOINT, toJson(creating), SC_BAD_REQUEST, USER9).asString();
+      String error = postWithStatus("note-types/", toJson(creating), HttpStatus.SC_BAD_REQUEST)
+        .asString();
 
       assertThat(error, containsString("duplicate key value"));
     } finally {
@@ -457,35 +473,12 @@ public class NoteTypesImplTest extends TestBase {
   }
 
   @Test
-  public void shouldReturn400WhenUserIdIsMissing() {
-    NoteType input = nextRandomNoteType();
-    RestAssured.given()
-      .spec(givenWithUrl())
-      .header(TENANT_HEADER).header(JSON_CONTENT_TYPE_HEADER)
-      .when()
-      .body(toJson(input))
-      .post(NOTE_TYPES_ENDPOINT)
-      .then()
-      .log().ifValidationFails()
-      .statusCode(SC_BAD_REQUEST)
-      .body(containsString("cannot look up user"));
-  }
-
-  @Test
-  public void shouldReturn400WhenUserIsRetrievedWithoutNecessaryFields() {
-    NoteType input = nextRandomNoteType();
-    final Header userWithoutPermission = new Header(XOkapiHeaders.USER_ID, "33999999-9999-4999-9999-999999999933");
-    final String response = postWithStatus(NOTE_TYPES_ENDPOINT,  toJson(input), SC_BAD_REQUEST, userWithoutPermission).asString();
-    MatcherAssert.assertThat(response, containsString("Missing fields"));
-  }
-
-  @Test
   public void shouldDeleteExistingNoteTypeById() {
     try {
       NoteType existing = nextRandomNoteType();
       DBTestUtil.insertNoteType(vertx, existing.getId(), STUB_TENANT, toJson(existing));
 
-      deleteWithOk(NOTE_TYPES_ENDPOINT + "/" + existing.getId());
+      deleteWithStatus("note-types/" + existing.getId(), HttpStatus.SC_NO_CONTENT);
 
       List<NoteType> noteTypes = DBTestUtil.getAllNoteTypes(vertx);
       assertEquals(0, noteTypes.size());
@@ -496,7 +489,7 @@ public class NoteTypesImplTest extends TestBase {
 
   @Test
   public void shouldFailOnDeleteWith404WhenNoteNotFound() {
-    deleteWithStatus(NOTE_TYPES_ENDPOINT + "/" + NOT_EXISTING_STUB_ID, SC_NOT_FOUND);
+    deleteWithStatus("note-types/" + NOT_EXISTING_STUB_ID, HttpStatus.SC_NOT_FOUND);
   }
 
   private NoteType loadSingleNote() {

--- a/src/test/java/org/folio/rest/impl/NoteTypesImplTest.java
+++ b/src/test/java/org/folio/rest/impl/NoteTypesImplTest.java
@@ -466,7 +466,7 @@ public class NoteTypesImplTest extends TestBase {
       String error = postWithStatus("note-types/", toJson(creating), HttpStatus.SC_BAD_REQUEST)
         .asString();
 
-      assertThat(error, containsString("duplicate key value"));
+      assertThat(error, containsString("already exists"));
     } finally {
       DBTestUtil.deleteAllNoteTypes(vertx);
     }

--- a/src/test/java/org/folio/rest/impl/NoteTypesImplTest.java
+++ b/src/test/java/org/folio/rest/impl/NoteTypesImplTest.java
@@ -6,7 +6,6 @@ import static org.apache.http.HttpStatus.SC_BAD_REQUEST;
 import static org.apache.http.HttpStatus.SC_NOT_FOUND;
 import static org.apache.http.HttpStatus.SC_UNPROCESSABLE_ENTITY;
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
 import static org.jeasy.random.FieldPredicates.named;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -106,6 +105,8 @@ public class NoteTypesImplTest extends TestBase {
           .withStatus(200)
           .withBody(readFile("users/mock_user_no_name.json"))
         ));
+
+    mockGet(CONFIG_NOTE_TYPE_LIMIT_URL_PATTERN, HttpStatus.SC_NOT_FOUND); // default limit will be applied
   }
 
   @Test
@@ -348,7 +349,7 @@ public class NoteTypesImplTest extends TestBase {
   @Test
   public void shouldReturn404WhenInvalidNotExistingId() {
     final String response = getWithStatus(NOTE_TYPES_ENDPOINT + "/" + NOT_EXISTING_STUB_ID, SC_NOT_FOUND).asString();
-    assertThat(response, equalTo("Not found"));
+    assertThat(response, containsString("not found"));
   }
 
   @Test
@@ -443,8 +444,6 @@ public class NoteTypesImplTest extends TestBase {
 
   @Test
   public void shouldFailOnPostWith400IfTypeAlreadyExists() {
-    mockGet(CONFIG_NOTE_TYPE_LIMIT_URL_PATTERN, HttpStatus.SC_NOT_FOUND); // default limit will be applied
-
     try {
       NoteType existing = nextRandomNoteType();
       DBTestUtil.insertNoteType(vertx, existing.getId(), STUB_TENANT, toJson(existing));

--- a/src/test/java/org/folio/spring/config/TestConfig.java
+++ b/src/test/java/org/folio/spring/config/TestConfig.java
@@ -1,0 +1,24 @@
+package org.folio.spring.config;
+
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+@Configuration
+@Import(ApplicationConfig.class)
+public class TestConfig {
+
+  @Bean
+  public Vertx vertx(){
+    //Initialize empty vertx object to be used by ApplicationConfig
+    return Vertx.vertx();
+  }
+
+  @Bean
+  public Context context(){
+    //Initialize empty context
+    return Vertx.vertx().getOrCreateContext();
+  }
+}

--- a/src/test/java/org/folio/userlookup/UserLookUpTest.java
+++ b/src/test/java/org/folio/userlookup/UserLookUpTest.java
@@ -3,12 +3,10 @@ package org.folio.userlookup;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 
-import io.vertx.core.Future;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 
 import javax.ws.rs.NotAuthorizedException;
 import javax.ws.rs.NotFoundException;
@@ -19,15 +17,15 @@ import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.github.tomakehurst.wiremock.matching.RegexPattern;
 import com.github.tomakehurst.wiremock.matching.UrlPathPattern;
-import io.vertx.core.Vertx;
+import io.vertx.core.Future;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
-import org.folio.okapi.common.XOkapiHeaders;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import org.folio.okapi.common.XOkapiHeaders;
 import org.folio.rest.TestBase;
 import org.folio.util.TestUtil;
 
@@ -35,7 +33,6 @@ import org.folio.util.TestUtil;
 public class UserLookUpTest {
   private static final String STUB_TENANT = "testlib";
   private static final String host = "http://127.0.0.1";
-  protected static Vertx vertx;
   private static Map<String, String> okapiHeaders = new HashMap<>();
   private final String GET_USER_ENDPOINT = "/users/";
   private static final String USER_INFO_STUB_FILE = "responses/userlookup/mock_user_response_200.json";
@@ -101,7 +98,7 @@ public class UserLookUpTest {
       async.complete();
       return null;
     }).otherwise(exception -> {
-      context.assertTrue(exception.getCause() instanceof NotAuthorizedException);
+      context.assertTrue(exception instanceof NotAuthorizedException);
       async.complete();
       return null;
     });
@@ -129,7 +126,7 @@ public class UserLookUpTest {
       async.complete();
       return null;
     }).otherwise(exception -> {
-      context.assertTrue(exception.getCause() instanceof NotFoundException);
+      context.assertTrue(exception instanceof NotFoundException);
       async.complete();
       return null;
     });
@@ -147,7 +144,7 @@ public class UserLookUpTest {
       async.complete();
       return null;
     }).otherwise(exception -> {
-      context.assertTrue(exception.getCause() instanceof IllegalStateException);
+      context.assertTrue(exception instanceof IllegalStateException);
       async.complete();
       return null;
     });

--- a/src/test/java/org/folio/util/TestUtil.java
+++ b/src/test/java/org/folio/util/TestUtil.java
@@ -1,10 +1,17 @@
 package org.folio.util;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 
+import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
+import com.github.tomakehurst.wiremock.matching.RegexPattern;
+import com.github.tomakehurst.wiremock.matching.StringValuePattern;
+import com.github.tomakehurst.wiremock.matching.UrlPathPattern;
 import io.vertx.core.json.Json;
 import org.apache.commons.io.FileUtils;
 
@@ -27,5 +34,16 @@ public class TestUtil {
 
   public static String toJson(Object object) {
     return Json.encode(object);
+  }
+
+  public static void mockGet(StringValuePattern urlPattern, String responseFile) throws IOException, URISyntaxException {
+    stubFor(get(new UrlPathPattern(urlPattern, (urlPattern instanceof RegexPattern)))
+      .willReturn(new ResponseDefinitionBuilder()
+        .withBody(readFile(responseFile))));
+  }
+
+  public static void mockGet(StringValuePattern urlPattern, int status) {
+    stubFor(get(new UrlPathPattern(urlPattern, (urlPattern instanceof RegexPattern)))
+      .willReturn(new ResponseDefinitionBuilder().withStatus(status)));
   }
 }

--- a/src/test/resources/responses/configuration/get-note-type-limit-5-response.json
+++ b/src/test/resources/responses/configuration/get-note-type-limit-5-response.json
@@ -1,0 +1,20 @@
+{
+  "configs": [
+    {
+      "id": "b3e0e211-8316-466a-88cf-1403f6272b36",
+      "module": "NOTES",
+      "configName": "note-type-limit",
+      "code": "note.types.number.limit",
+      "description": "maximum number of note types allowed",
+      "default": true,
+      "enabled": true,
+      "value": "5"
+    }
+  ],
+  "totalRecords": 1,
+  "resultInfo": {
+    "totalRecords": 1,
+    "facets": [],
+    "diagnostics": []
+  }
+}

--- a/src/test/resources/responses/configuration/get-note-type-limit-disabled-response.json
+++ b/src/test/resources/responses/configuration/get-note-type-limit-disabled-response.json
@@ -1,0 +1,20 @@
+{
+  "configs": [
+    {
+      "id": "b3e0e211-8316-466a-88cf-1403f6272b36",
+      "module": "NOTES",
+      "configName": "note-type-limit",
+      "code": "note.types.number.limit",
+      "description": "maximum number of note types allowed",
+      "default": true,
+      "enabled": false,
+      "value": "5"
+    }
+  ],
+  "totalRecords": 1,
+  "resultInfo": {
+    "totalRecords": 1,
+    "facets": [],
+    "diagnostics": []
+  }
+}

--- a/src/test/resources/responses/configuration/get-note-type-limit-empty-response.json
+++ b/src/test/resources/responses/configuration/get-note-type-limit-empty-response.json
@@ -1,0 +1,9 @@
+{
+  "configs": [],
+  "totalRecords": 0,
+  "resultInfo": {
+    "totalRecords": 0,
+    "facets": [],
+    "diagnostics": []
+  }
+}

--- a/src/test/resources/responses/configuration/get-note-type-limit-no-value-response.json
+++ b/src/test/resources/responses/configuration/get-note-type-limit-no-value-response.json
@@ -1,0 +1,20 @@
+{
+  "configs": [
+    {
+      "id": "b3e0e211-8316-466a-88cf-1403f6272b36",
+      "module": "NOTES",
+      "configName": "note-type-limit",
+      "code": "note.types.number.limit",
+      "description": "maximum number of note types allowed",
+      "default": true,
+      "enabled": true,
+      "value": ""
+    }
+  ],
+  "totalRecords": 1,
+  "resultInfo": {
+    "totalRecords": 1,
+    "facets": [],
+    "diagnostics": []
+  }
+}

--- a/src/test/resources/responses/configuration/get-note-type-limit-not-unique-response.json
+++ b/src/test/resources/responses/configuration/get-note-type-limit-not-unique-response.json
@@ -1,0 +1,30 @@
+{
+  "configs": [
+    {
+      "id": "b3e0e211-8316-466a-88cf-1403f6272b36",
+      "module": "NOTES",
+      "configName": "note-type-limit",
+      "code": "note.types.number.limit",
+      "description": "maximum number of note types allowed",
+      "default": true,
+      "enabled": true,
+      "value": "5"
+    },
+    {
+      "id": "8c697f0b-cc7e-4294-a403-b9d1343a2df4",
+      "module": "NOTES",
+      "configName": "note-type-limit",
+      "code": "note.types.number.limit",
+      "description": "maximum number of note types allowed (DUPLICATE)",
+      "default": true,
+      "enabled": true,
+      "value": "10"
+    }
+  ],
+  "totalRecords": 2,
+  "resultInfo": {
+    "totalRecords": 2,
+    "facets": [],
+    "diagnostics": []
+  }
+}


### PR DESCRIPTION
## Purpose
According to [MODNOTES-71](https://issues.folio.org/browse/MODNOTES-71), limit the number of possible note types in the system by doing a check during note type creation.
The number by default is 25 but can be changed by providing a setting in mod-configuration with:
- module == NOTES
- code == note.types.number.limit

## Approach
- refactor the code to separate REST layer from DB and service logic
- implement the validation inside post method note type service

Code related to the validation resides mostly inside this [commit](https://github.com/folio-org/mod-notes/commit/8c4ff9bdfbf3f63686615a106ec2fc43cc72844f). The rest is refactoring and merging

