### PR TITLE
MODNOTES-96 - Check note title and detail limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ etc.
 
 ### Code analysis
 
-[SonarQube analysis](https://sonarcloud.io/dashboard?id=org.folio.rest%3Amod-notes).
+[SonarQube analysis](https://sonarcloud.io/dashboard?id=org.folio%3Amod-notes).
 
 ### Download and configuration
 

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -5,6 +5,10 @@
     {
       "id": "users",
       "version": "15.0"
+    },
+    {
+      "id": "configuration",
+      "version": "2.0"
     }
   ],
   "provides": [

--- a/ramls/types/notes/note.json
+++ b/ramls/types/notes/note.json
@@ -27,11 +27,13 @@
     },
     "title": {
       "type": "string",
+      "maxLength": 75,
       "description": "Note title",
       "example": "BU Campus only issues"
     },
     "content": {
       "type": "string",
+      "maxLength": 1500,
       "description": "Content of the note",
       "example": "There are access issues at BU campus"
     },

--- a/run.sh
+++ b/run.sh
@@ -328,7 +328,7 @@ $CURL $TEN \
   $OKAPIURL/notes?query='link=*56*'
 echo
 
-echo Test 13: permissions for item get - Expect a 403
+echo Test 13: Post without permission - Expect a 401
 $CURL $TEN \
   $OKAPIURL/notes/44444444-4444-4444-4444-444444444444
 echo

--- a/src/test/java/org/folio/rest/impl/DBTestUtil.java
+++ b/src/test/java/org/folio/rest/impl/DBTestUtil.java
@@ -30,8 +30,20 @@ public class DBTestUtil {
     future.join();
   }
 
+  public static void insertNote(Vertx vertx, String stubId, String tenantId, String json) {
+    CompletableFuture<Void> future = new CompletableFuture<>();
+    PostgresClient.getInstance(vertx).execute(
+      "INSERT INTO " + getNoteTableName(tenantId) + "(" + " id, " + JSONB_COLUMN + ") VALUES ('" + stubId + "' , '" + json + "');" ,
+      event -> future.complete(null));
+    future.join();
+  }
+
   private static String getNoteTypesTableName(String tenantId) {
     return PostgresClient.convertToPsqlStandard(tenantId) + "." + NOTE_TYPE_TABLE;
+  }
+
+  private static String getNoteTableName(String tenantId) {
+    return PostgresClient.convertToPsqlStandard(tenantId) + "." + NOTE_TABLE;
   }
 
 
@@ -47,7 +59,7 @@ public class DBTestUtil {
     return future.join();
   }
 
-  public static void deleteFromTable(Vertx vertx, String tableName) {
+  private static void deleteFromTable(Vertx vertx, String tableName) {
     CompletableFuture<Void> future = new CompletableFuture<>();
     PostgresClient.getInstance(vertx).execute(
       "DELETE FROM " + tableName,
@@ -66,5 +78,9 @@ public class DBTestUtil {
 
   public static void deleteAllNoteTypes(Vertx vertx) {
     deleteFromTable(vertx, getNoteTypesTableName(STUB_TENANT));
+  }
+
+  public static void deleteAllNotes(Vertx vertx) {
+    deleteFromTable(vertx, getNoteTableName(STUB_TENANT));
   }
 }

--- a/src/test/java/org/folio/rest/impl/NoteLinksImplTest.java
+++ b/src/test/java/org/folio/rest/impl/NoteLinksImplTest.java
@@ -36,7 +36,6 @@ import org.folio.rest.jaxrs.model.Note;
 import org.folio.rest.jaxrs.model.NoteCollection;
 import org.folio.rest.jaxrs.model.NoteLinkPut;
 import org.folio.rest.jaxrs.model.NoteLinksPut;
-import org.folio.rest.persist.PostgresClient;
 
 @RunWith(VertxUnitRunner.class)
 public class NoteLinksImplTest extends TestBase {
@@ -63,8 +62,7 @@ public class NoteLinksImplTest extends TestBase {
 
   @After
   public void tearDown() {
-    DBTestUtil.deleteFromTable(vertx,
-      (PostgresClient.convertToPsqlStandard(STUB_TENANT) + "." + DBTestUtil.NOTE_TABLE));
+    DBTestUtil.deleteAllNotes(vertx);
   }
 
   @Test

--- a/src/test/java/org/folio/rest/impl/NoteTypesImplTest.java
+++ b/src/test/java/org/folio/rest/impl/NoteTypesImplTest.java
@@ -52,7 +52,6 @@ import org.folio.rest.TestBase;
 import org.folio.rest.jaxrs.model.Metadata;
 import org.folio.rest.jaxrs.model.NoteType;
 import org.folio.rest.jaxrs.model.NoteTypeUsage;
-import org.folio.rest.persist.PostgresClient;
 import org.folio.spring.SpringContextUtil;
 
 @RunWith(VertxUnitRunner.class)
@@ -124,7 +123,7 @@ public class NoteTypesImplTest extends TestBase {
 
       getWithOk(NOTE_TYPES_ENDPOINT + "/" + STUB_NOTE_TYPE_ID).asString();
     } finally {
-      DBTestUtil.deleteFromTable(vertx, (PostgresClient.convertToPsqlStandard(STUB_TENANT) + "." + DBTestUtil.NOTE_TYPE_TABLE));
+      DBTestUtil.deleteAllNoteTypes(vertx);
     }
   }
 
@@ -140,9 +139,8 @@ public class NoteTypesImplTest extends TestBase {
       getWithValidateBody(NOTE_TYPES_ENDPOINT +"/" + STUB_NOTE_TYPE_ID,SC_OK)
         .body("usage.noteTotal",is(2));
     } finally {
-      DBTestUtil.deleteFromTable(vertx,
-        (PostgresClient.convertToPsqlStandard(STUB_TENANT) + "." + DBTestUtil.NOTE_TABLE));
-      DBTestUtil.deleteFromTable(vertx, (PostgresClient.convertToPsqlStandard(STUB_TENANT) + "." + DBTestUtil.NOTE_TYPE_TABLE));
+      DBTestUtil.deleteAllNotes(vertx);
+      DBTestUtil.deleteAllNoteTypes(vertx);
     }
   }
 
@@ -158,9 +156,8 @@ public class NoteTypesImplTest extends TestBase {
       getWithValidateBody(NOTE_TYPES_ENDPOINT,SC_OK)
         .body("noteTypes[0].usage.noteTotal",is(2));
     } finally {
-      DBTestUtil.deleteFromTable(vertx,
-        (PostgresClient.convertToPsqlStandard(STUB_TENANT) + "." + DBTestUtil.NOTE_TABLE));
-      DBTestUtil.deleteFromTable(vertx, (PostgresClient.convertToPsqlStandard(STUB_TENANT) + "." + DBTestUtil.NOTE_TYPE_TABLE));
+      DBTestUtil.deleteAllNotes(vertx);
+      DBTestUtil.deleteAllNoteTypes(vertx);
     }
   }
 
@@ -179,7 +176,7 @@ public class NoteTypesImplTest extends TestBase {
       assertEquals(1, noteTypes.size());
       assertEquals(1, totalRecords);
     } finally {
-      DBTestUtil.deleteFromTable(vertx, (PostgresClient.convertToPsqlStandard(STUB_TENANT) + "." + DBTestUtil.NOTE_TYPE_TABLE));
+      DBTestUtil.deleteAllNoteTypes(vertx);
     }
   }
 
@@ -201,7 +198,7 @@ public class NoteTypesImplTest extends TestBase {
       assertEquals(1, noteTypeList.size());
       assertEquals(3, totalRecords);
     } finally {
-      DBTestUtil.deleteFromTable(vertx, (PostgresClient.convertToPsqlStandard(STUB_TENANT) + "." + DBTestUtil.NOTE_TYPE_TABLE));
+      DBTestUtil.deleteAllNoteTypes(vertx);
     }
   }
 
@@ -222,7 +219,7 @@ public class NoteTypesImplTest extends TestBase {
       assertEquals(3, noteTypeList.size());
       assertEquals(3, totalRecords);
     } finally {
-      DBTestUtil.deleteFromTable(vertx, (PostgresClient.convertToPsqlStandard(STUB_TENANT) + "." + DBTestUtil.NOTE_TYPE_TABLE));
+      DBTestUtil.deleteAllNoteTypes(vertx);
     }
   }
 
@@ -243,7 +240,7 @@ public class NoteTypesImplTest extends TestBase {
       assertEquals(0, noteTypeList.size());
       assertEquals(3, totalRecords);
     } finally {
-      DBTestUtil.deleteFromTable(vertx, (PostgresClient.convertToPsqlStandard(STUB_TENANT) + "." + DBTestUtil.NOTE_TYPE_TABLE));
+      DBTestUtil.deleteAllNoteTypes(vertx);
     }
   }
 
@@ -264,7 +261,7 @@ public class NoteTypesImplTest extends TestBase {
       assertEquals(3, noteTypeList.size());
       assertEquals(3, totalRecords);
     } finally {
-      DBTestUtil.deleteFromTable(vertx, (PostgresClient.convertToPsqlStandard(STUB_TENANT) + "." + DBTestUtil.NOTE_TYPE_TABLE));
+      DBTestUtil.deleteAllNoteTypes(vertx);
     }
   }
 
@@ -285,7 +282,7 @@ public class NoteTypesImplTest extends TestBase {
       assertEquals(0, noteTypeList.size());
       assertEquals(3, totalRecords);
     } finally {
-      DBTestUtil.deleteFromTable(vertx, (PostgresClient.convertToPsqlStandard(STUB_TENANT) + "." + DBTestUtil.NOTE_TYPE_TABLE));
+      DBTestUtil.deleteAllNoteTypes(vertx);
     }
   }
 
@@ -294,7 +291,7 @@ public class NoteTypesImplTest extends TestBase {
     try {
       getWithStatus(NOTE_TYPES_ENDPOINT + "&limit=-1", SC_BAD_REQUEST);
     } finally {
-      DBTestUtil.deleteFromTable(vertx, (PostgresClient.convertToPsqlStandard(STUB_TENANT) + "." + DBTestUtil.NOTE_TYPE_TABLE));
+      DBTestUtil.deleteAllNoteTypes(vertx);
     }
   }
 
@@ -303,7 +300,7 @@ public class NoteTypesImplTest extends TestBase {
     try {
       getWithStatus(NOTE_TYPES_ENDPOINT + "&offset=-1", SC_BAD_REQUEST);
     } finally {
-      DBTestUtil.deleteFromTable(vertx, (PostgresClient.convertToPsqlStandard(STUB_TENANT) + "." + DBTestUtil.NOTE_TYPE_TABLE));
+      DBTestUtil.deleteAllNoteTypes(vertx);
     }
   }
 
@@ -343,7 +340,7 @@ public class NoteTypesImplTest extends TestBase {
       assertEquals(1, noteTypes.size());
       assertEquals(1, totalRecords);
     } finally {
-      DBTestUtil.deleteFromTable(vertx, (PostgresClient.convertToPsqlStandard(STUB_TENANT) + "." + DBTestUtil.NOTE_TYPE_TABLE));
+      DBTestUtil.deleteAllNoteTypes(vertx);
     }
   }
 
@@ -358,7 +355,7 @@ public class NoteTypesImplTest extends TestBase {
       assertEquals(0, noteTypes.size());
       assertEquals(0, totalRecords);
     } finally {
-      DBTestUtil.deleteFromTable(vertx, (PostgresClient.convertToPsqlStandard(STUB_TENANT) + "." + DBTestUtil.NOTE_TYPE_TABLE));
+      DBTestUtil.deleteAllNoteTypes(vertx);
     }
   }
 
@@ -371,7 +368,7 @@ public class NoteTypesImplTest extends TestBase {
 
       getWithStatus(NOTE_TYPES_ENDPOINT + "?query=", SC_BAD_REQUEST);
     } finally {
-      DBTestUtil.deleteFromTable(vertx, (PostgresClient.convertToPsqlStandard(STUB_TENANT) + "." + DBTestUtil.NOTE_TYPE_TABLE));
+      DBTestUtil.deleteAllNoteTypes(vertx);
     }
   }
 
@@ -384,7 +381,7 @@ public class NoteTypesImplTest extends TestBase {
 
       getWithStatus(NOTE_TYPES_ENDPOINT + "?limit=", SC_BAD_REQUEST);
     } finally {
-      DBTestUtil.deleteFromTable(vertx, (PostgresClient.convertToPsqlStandard(STUB_TENANT) + "." + DBTestUtil.NOTE_TYPE_TABLE));
+      DBTestUtil.deleteAllNoteTypes(vertx);
     }
   }
 
@@ -420,7 +417,7 @@ public class NoteTypesImplTest extends TestBase {
       assertEquals("m8", noteTypeMetadata.getUpdatedByUsername());
 
     } finally {
-      DBTestUtil.deleteFromTable(vertx, (PostgresClient.convertToPsqlStandard(STUB_TENANT) + "." + DBTestUtil.NOTE_TYPE_TABLE));
+      DBTestUtil.deleteAllNoteTypes(vertx);
     }
   }
 
@@ -437,7 +434,7 @@ public class NoteTypesImplTest extends TestBase {
       NoteType loaded = loadSingleNote();
       assertNull(loaded.getUsage());
     } finally {
-      DBTestUtil.deleteFromTable(vertx, (PostgresClient.convertToPsqlStandard(STUB_TENANT) + "." + DBTestUtil.NOTE_TYPE_TABLE));
+      DBTestUtil.deleteAllNoteTypes(vertx);
     }
   }
 

--- a/src/test/java/org/folio/rest/impl/NotesTest.java
+++ b/src/test/java/org/folio/rest/impl/NotesTest.java
@@ -21,6 +21,8 @@ import static org.folio.util.NoteTestData.NOTE_1;
 import static org.folio.util.NoteTestData.NOTE_2;
 import static org.folio.util.NoteTestData.NOTE_3;
 import static org.folio.util.NoteTestData.NOTE_4;
+import static org.folio.util.NoteTestData.NOTE_5_LONG_CONTENT;
+import static org.folio.util.NoteTestData.NOTE_5_LONG_TITLE;
 import static org.folio.util.NoteTestData.NOTE_TYPE2_ID;
 import static org.folio.util.NoteTestData.NOTE_TYPE2_NAME;
 import static org.folio.util.NoteTestData.NOTE_TYPE_ID;
@@ -60,7 +62,6 @@ import org.folio.rest.jaxrs.model.Errors;
 import org.folio.rest.jaxrs.model.Metadata;
 import org.folio.rest.jaxrs.model.Note;
 import org.folio.rest.jaxrs.model.NoteCollection;
-import org.folio.rest.persist.PostgresClient;
 
 /**
  * Interface test for mod-notes. Tests the API with restAssured, directly
@@ -125,8 +126,7 @@ public class NotesTest extends TestBase {
 
   @After
   public void tearDown() {
-    DBTestUtil.deleteFromTable(vertx,
-      (PostgresClient.convertToPsqlStandard(STUB_TENANT) + "." + DBTestUtil.NOTE_TABLE));
+    DBTestUtil.deleteAllNotes(vertx);
   }
 
   @Test
@@ -393,7 +393,7 @@ public class NotesTest extends TestBase {
       .log().ifValidationFails()
       .statusCode(SC_BAD_REQUEST);
 
-    DBTestUtil.deleteFromTable(vertx, DBTestUtil.NOTE_TABLE);
+    DBTestUtil.deleteAllNotes(vertx);
   }
 
   @Test
@@ -432,13 +432,22 @@ public class NotesTest extends TestBase {
   }
 
   @Test
+  public void shouldReturn422WhenPostNoteTitleIsTooLong(){
+    postWithStatus(NOTES_PATH, NOTE_5_LONG_TITLE, SC_UNPROCESSABLE_ENTITY, USER8);
+  }
+
+  @Test
+  public void shouldReturn422WhenPostNoteContentIsTooLong(){
+    postWithStatus(NOTES_PATH, NOTE_5_LONG_CONTENT, SC_UNPROCESSABLE_ENTITY, USER8);
+  }
+
+  @Test
   public void shouldReturn422WhenUpdatingNoteWithNotMatchingId() {
     final String response = putWithStatus("/notes/22222222-2222-2222-a222-222222222222",
       UPDATE_NOTE_REQUEST, SC_UNPROCESSABLE_ENTITY, USER8).asString();
 
     assertThat(response, containsString("Can not change Id"));
   }
-
 
   @Test
   public void shouldReturn422WhenUpdatingNoteWithInvalidId() {
@@ -510,6 +519,18 @@ public class NotesTest extends TestBase {
   @Test
   public void shouldReturn404WhenDeleteRequestHasNotExistingUUID() {
     deleteWithStatus("/notes/11111111-2222-3333-a444-555555555555", SC_NOT_FOUND);
+  }
+
+  @Test
+  public void shouldReturn422WhenPutNoteTitleIsTooLong(){
+    postNoteWithOk(NOTE_4, USER8);
+    putWithStatus("/notes/33333333-1111-1111-a333-333333333333", NOTE_5_LONG_TITLE, SC_UNPROCESSABLE_ENTITY, USER8);
+  }
+
+  @Test
+  public void shouldReturn422WhenPutNoteContentIsTooLong(){
+    postNoteWithOk(NOTE_4, USER8);
+    putWithStatus("/notes/33333333-1111-1111-a333-333333333333", NOTE_5_LONG_CONTENT, SC_UNPROCESSABLE_ENTITY, USER8);
   }
 
   @Test

--- a/src/test/java/org/folio/util/NoteTestData.java
+++ b/src/test/java/org/folio/util/NoteTestData.java
@@ -33,6 +33,8 @@ public class NoteTestData {
   public static final String NOTE_4;
   public static final String UPDATE_NOTE_4_REQUEST;
   public static final String UPDATE_NOTE_5_REQUEST_WITH_NON_EXISTING_TYPE_ID;
+  public static final String NOTE_5_LONG_TITLE;
+  public static final String NOTE_5_LONG_CONTENT;
   public static final String NOTE_TYPE;
   public static final String NOTE_TYPE2;
   public static final String UPDATE_NOTE_2_REQUEST_WITH_NO_LINKS;
@@ -47,6 +49,8 @@ public class NoteTestData {
       NOTE_4 = TestUtil.readFile("note/note4.json");
       UPDATE_NOTE_4_REQUEST = TestUtil.readFile("note/updateNote4Request.json");
       UPDATE_NOTE_5_REQUEST_WITH_NON_EXISTING_TYPE_ID = TestUtil.readFile("note/updateNote5RequestWithNonExistingTypeId.json");
+      NOTE_5_LONG_TITLE = TestUtil.readFile("note/note5LongTitle.json");
+      NOTE_5_LONG_CONTENT = TestUtil.readFile("note/note6LongContent.json");
       NOTE_TYPE = TestUtil.readFile("notetype/noteType.json");
       NOTE_TYPE2 = TestUtil.readFile("notetype/noteType2.json");
       UPDATE_NOTE_2_REQUEST_WITH_NO_LINKS = TestUtil.readFile("note/updateNoteRequestWithNoId.json");

--- a/src/test/resources/note/note5LongTitle.json
+++ b/src/test/resources/note/note5LongTitle.json
@@ -1,0 +1,13 @@
+{
+  "id": "33333333-1111-1111-a333-333333333333",
+  "typeId": "13f21797-d25b-46dc-8427-1759d1db2057",
+  "title": "Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo lig",
+  "domain": "eholdings",
+  "content": "Test on things",
+  "links": [
+    {
+      "id": "123-456789",
+      "type": "package"
+    }
+  ]
+}

--- a/src/test/resources/note/note6LongContent.json
+++ b/src/test/resources/note/note6LongContent.json
@@ -1,0 +1,13 @@
+{
+  "id": "33333333-1111-1111-a333-333333333333",
+  "typeId": "13f21797-d25b-46dc-8427-1759d1db2057",
+  "title": "test title",
+  "domain": "eholdings",
+  "content": "Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium. Integer tincidunt. Cras dapibus. Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. Aenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante, dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel augue. Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus. Maecenas tempus, tellus eget condimentum rhoncus, sem quam semper libero, sit amet adipiscing sem neque sed ipsum. Nam quam nunc, blandit vel, luctus pulvinar, hendrerit id, lorem. Maecenas nec odio et ante tincidunt tempus. Donec vitae sapien ut libero venenatis faucibus. Nullam quis ante. Etiam sit amet orci eget eros faucibus tincidunt. Duis leo. Sed fringilla mauris sit amet nibh. Donec sodales sagittis magna. Sed consequat, leo eget bibendum sodales, augue velit cursus nunc, quis gravida magna mi a libero. Fusce vulputate eleifend sapien. Vestibulum purus quam, scelerisque ut, mollis sed, nonummy id, metu",
+  "links": [
+    {
+      "id": "123-456789",
+      "type": "package"
+    }
+  ]
+}


### PR DESCRIPTION
## Purpose
Due to https://issues.folio.org/browse/MODNOTES-96 we want to add restrictions to note title and content length.

## Approach
* added database restriction on note title and content limit
* added json schema restriction on note title and content limit
* added tests

