### PR TITLE
FOLIO-2003 initial module metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Run the local stand-alone instance:
 
 ```
 java -jar target/mod-notes-fat.jar \
-  -Dhttp.port=8085 embed_postgres=true
+  -Dhttp.port=8081 embed_postgres=true
 ```
 
 ### API documentation
@@ -76,8 +76,8 @@ This module's [API documentation](https://dev.folio.org/reference/api/#mod-notes
 
 The local API docs are available, for example:
 ```
-http://localhost:8085/apidocs/?raml=raml/note.raml
-http://localhost:8085/apidocs/?raml=raml/admin.raml
+http://localhost:8081/apidocs/?raml=raml/note.raml
+http://localhost:8081/apidocs/?raml=raml/admin.raml
 etc.
 ```
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ java -jar target/mod-notes-fat.jar \
   -Dhttp.port=8081 embed_postgres=true
 ```
 
+See the built `target/ModuleDescriptor.json` for the interfaces that this module
+requires and provides, the permissions, and the additional module metadata.
+
 ### API documentation
 
 This module's [API documentation](https://dev.folio.org/reference/api/#mod-notes).

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -204,6 +204,10 @@
       "visible": false
     }
   ],
+  "metadata": {
+    "containerMemory": "256",
+    "databaseConnection": "true"
+  },
   "launchDescriptor": {
     "dockerImage": "${artifactId}:${version}",
     "dockerArgs": {


### PR DESCRIPTION
Declare additional module metadata in ModuleDescriptor: containerMemory, databaseConnection

[FOLIO-2003](https://issues.folio.org/browse/FOLIO-2003)