### PR TITLE
FOLIO-2003 initial module metadata, undo because old folio-registry

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -204,10 +204,6 @@
       "visible": false
     }
   ],
-  "metadata": {
-    "containerMemory": "256",
-    "databaseConnection": "true"
-  },
   "launchDescriptor": {
     "dockerImage": "${artifactId}:${version}",
     "dockerArgs": {


### PR DESCRIPTION
Undo the MD change from last commit to add "metadata" to MD: #105

The okapi serving folio-registry needs to be updated.