### PR TITLE
FOLIO-2003 initial module metadata 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ java -jar target/mod-notes-fat.jar \
   -Dhttp.port=8081 embed_postgres=true
 ```
 
+### ModuleDescriptor
+
 See the built `target/ModuleDescriptor.json` for the interfaces that this module
 requires and provides, the permissions, and the additional module metadata.
 

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -204,6 +204,10 @@
       "visible": false
     }
   ],
+  "metadata": {
+    "containerMemory": "256",
+    "databaseConnection": "true"
+  },
   "launchDescriptor": {
     "dockerImage": "${artifactId}:${version}",
     "dockerArgs": {


### PR DESCRIPTION
Declare additional module metadata in ModuleDescriptor: containerMemory, databaseConnection

[FOLIO-2003](https://issues.folio.org/browse/FOLIO-2003)

(Doing again, now that folio-registry okapi is updated FOLIO-2016.)