### PR TITLE
MODNOTES-102 Add endpoint for searching notes by assignment status

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -70,6 +70,11 @@
           "methods": ["PUT"],
           "pathPattern": "/note-links/type/{type}/id/{id}",
           "permissionsRequired": ["note.links.collection.put"]
+        },
+        {
+          "methods": ["GET"],
+          "pathPattern": "/note-links/domain/{domain}/type/{type}/id/{id}",
+          "permissionsRequired": ["notes.collection.get.by.status"]
         }
       ]
     },
@@ -170,6 +175,11 @@
       "description": "Update note links"
     },
     {
+      "permissionName": "notes.collection.get.by.status",
+      "displayName": "Notes - get notes collection sorted by status",
+      "description": "Get notes collection by status and domain"
+    },
+    {
       "permissionName": "notes.allops",
       "displayName": "Notes module - all CRUD permissions",
       "description": "Entire set of permissions needed to use the notes modules, but no domain permissions",
@@ -179,7 +189,8 @@
         "notes.item.post",
         "notes.item.put",
         "notes.item.delete",
-        "note.links.collection.put"
+        "note.links.collection.put",
+        "notes.collection.get.by.status"
       ],
       "visible": false
     },

--- a/ramls/link.raml
+++ b/ramls/link.raml
@@ -10,10 +10,15 @@ documentation:
 types:
   noteLinksPut: !include types/link/noteLinksPut.json
   errors: !include raml-util/schemas/errors.schema
+  noteCollection: !include types/notes/noteCollection.json
+  note: !include types/notes/note.json
 
 traits:
   validate: !include raml-util/traits/validation.raml
   language: !include raml-util/traits/language.raml
+  pageable: !include raml-util/traits/pageable.raml
+  searchable: !include raml-util/traits/searchable.raml
+  orderable: !include raml-util/traits/orderable.raml
 
 /note-links:
   /type/{type}/id/{id}/:
@@ -46,3 +51,50 @@ traits:
             body:
               text/plain:
                 example: "internal server error, contact administrator"
+  /domain/{domain}/type/{type}/id/{id}/:
+    get:
+        is: [
+        validate,
+        pageable
+        ]
+        description: Return a list of notes by status
+        queryParameters:
+          status:
+            displayName: Selection status
+            type: string
+            description: Filtering records by status. Possible values are ASSIGNED, UNASSIGNED, all.
+            example: ASSIGNED
+            required: false
+            default: ALL
+          order:
+            displayName: Selection status
+            type: string
+            description: Orderable value indicates order of records. Possible values asc, desc.
+            example: asc
+            required: false
+            default: asc
+        responses:
+           200:
+             description: "Return a list of notes"
+             body:
+               application/json:
+                 type: noteCollection
+                 example:
+                  strict: false
+                  value: !include examples/noteCollection.sample
+           400:
+             description: "Bad request, e.g. malformed request body. Details of the error (e.g. name of the parameter or line/character number with malformed data) provided in the response."
+             body:
+               text/plain:
+                 example: |
+                   "unable to get list -- malformed JSON at 13:4"
+           401:
+             description: "Not authorized to perform requested action"
+             body:
+               text/plain:
+                  example: "unable to list -- unauthorized"
+           500:
+             description: "Internal server error"
+             body:
+                text/plain:
+                 example: "internal server error, contact administrator"

--- a/ramls/link.raml
+++ b/ramls/link.raml
@@ -62,14 +62,14 @@ traits:
           status:
             displayName: Selection status
             type: string
-            description: Filtering records by status. Possible values are ASSIGNED, UNASSIGNED, all.
+            description: Filtering records by status. Possible values are ASSIGNED, UNASSIGNED, ALL, assigned, unassigned, all.
             example: ASSIGNED
             required: false
             default: ALL
           order:
             displayName: Selection status
             type: string
-            description: Orderable value indicates order of records. Possible values asc, desc.
+            description: Orderable value indicates order of records. Possible values asc, desc, DESC, ASC.
             example: asc
             required: false
             default: asc

--- a/src/main/java/org/folio/rest/model/Order.java
+++ b/src/main/java/org/folio/rest/model/Order.java
@@ -1,0 +1,25 @@
+package org.folio.rest.model;
+
+public enum Order {
+
+  ASC("asc"), DESC("desc");
+
+  private String value;
+
+  Order(String value) {
+    this.value = value;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  public static boolean contains(String value) {
+    for (Order c : Order.values()) {
+      if (c.name().equals(value)) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/src/main/java/org/folio/rest/model/Status.java
+++ b/src/main/java/org/folio/rest/model/Status.java
@@ -1,0 +1,27 @@
+package org.folio.rest.model;
+
+public enum Status {
+
+  ASSIGNED("ASSIGNED"),
+  UNASSIGNED("UNASSIGNED"),
+  ALL("ALL");
+
+  private String value;
+
+  Status(String value) {
+    this.value = value;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  public static boolean contains(String value) {
+    for (Status c : Status.values()) {
+      if (c.name().equals(value)) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/src/test/java/org/folio/rest/impl/NoteLinksImplTest.java
+++ b/src/test/java/org/folio/rest/impl/NoteLinksImplTest.java
@@ -191,11 +191,46 @@ public class NoteLinksImplTest extends TestBase {
     Note firstNote = createNote();
     createNote();
 
-    List<Note> notes = getWithOk("/note-links/domain/" + DOMAIN + "/type/" + PACKAGE_TYPE + "/id/123-456789").as(
-      NoteCollection.class).getNotes();
+    List<Note> notes = getWithOk("/note-links/domain/" + DOMAIN + "/type/" + PACKAGE_TYPE + "/id/123-456789")
+      .as(NoteCollection.class)
+      .getNotes();
 
     assertEquals(2, notes.size());
     assertEquals(DEFAULT_LINK_AMOUNT, firstNote.getLinks().size());
+  }
+
+  @Test
+  public void shouldReturnEmptyNoteCollection() {
+
+    List<Note> notes = getWithOk("/note-links/domain/" + DOMAIN + "/type/" + PACKAGE_TYPE + "/id/123-456789")
+      .as(NoteCollection.class)
+      .getNotes();
+
+    assertEquals(0, notes.size());
+  }
+
+  @Test
+  public void shouldReturnListOfNotesWithLimit() {
+    createNote();
+    createNote();
+
+    List<Note> notes = getWithOk("/note-links/domain/" + DOMAIN + "/type/" + PACKAGE_TYPE + "/id/123-456789?limit=1")
+      .as(NoteCollection.class)
+      .getNotes();
+
+    assertEquals(1, notes.size());
+  }
+
+  @Test
+  public void shouldReturnListOfNotesWithOffset() {
+    createNote();
+    createNote();
+
+    List<Note> notes = getWithOk("/note-links/domain/" + DOMAIN + "/type/" + PACKAGE_TYPE + "/id/123-456789?offset=1")
+      .as(NoteCollection.class)
+      .getNotes();
+
+    assertEquals(1, notes.size());
   }
 
   @Test
@@ -204,8 +239,9 @@ public class NoteLinksImplTest extends TestBase {
     createNote();
 
     List<Note> notes = getWithOk(
-      "/note-links/domain/" + DOMAIN + "/type/" + PACKAGE_TYPE + "/id/" + NON_EXISTING_ID).as(
-      NoteCollection.class).getNotes();
+      "/note-links/domain/" + DOMAIN + "/type/" + PACKAGE_TYPE + "/id/" + NON_EXISTING_ID)
+      .as(NoteCollection.class)
+      .getNotes();
 
     assertEquals(2, notes.size());
     assertEquals(DEFAULT_LINK_AMOUNT, firstNote.getLinks().size());
@@ -216,8 +252,9 @@ public class NoteLinksImplTest extends TestBase {
     Note firstNote = createNote();
     createNote();
 
-    List<Note> notes = getWithOk("/note-links/domain/" + DOMAIN + "/type/" + PACKAGE_TYPE + "/id/" + INVALID_ID).as(
-      NoteCollection.class).getNotes();
+    List<Note> notes = getWithOk("/note-links/domain/" + DOMAIN + "/type/" + PACKAGE_TYPE + "/id/" + INVALID_ID)
+      .as(NoteCollection.class)
+      .getNotes();
 
     assertEquals(2, notes.size());
     assertEquals(DEFAULT_LINK_AMOUNT, firstNote.getLinks().size());
@@ -230,7 +267,8 @@ public class NoteLinksImplTest extends TestBase {
 
     List<Note> notes = getWithOk(
       "/note-links/domain/" + DOMAIN + "/type/" + PACKAGE_TYPE + "/id/" + PACKAGE_ID + "?orde")
-      .as(NoteCollection.class).getNotes();
+      .as(NoteCollection.class)
+      .getNotes();
 
     assertEquals(2, notes.size());
     assertEquals(DEFAULT_LINK_AMOUNT, firstNote.getLinks().size());
@@ -242,7 +280,9 @@ public class NoteLinksImplTest extends TestBase {
     createLinks(firstNote.getId());
 
     List<Note> notes = getWithOk("/note-links/domain/" + DOMAIN + "/type/" + PACKAGE_TYPE + "/id/" + PACKAGE_ID
-      + "?status=ASSIGNED").as(NoteCollection.class).getNotes();
+      + "?status=ASSIGNED")
+      .as(NoteCollection.class)
+      .getNotes();
 
     assertEquals(1, notes.size());
     assertEquals(DEFAULT_LINK_AMOUNT, firstNote.getLinks().size());
@@ -255,7 +295,9 @@ public class NoteLinksImplTest extends TestBase {
     createLinks(firsNoteWithAssignedLink.getId());
 
     List<Note> notes = getWithOk("/note-links/domain/" + DOMAIN + "/type/" + PACKAGE_TYPE + "/id/" + PACKAGE_ID
-      + "?status=UNASSIGNED").as(NoteCollection.class).getNotes();
+      + "?status=UNASSIGNED")
+      .as(NoteCollection.class)
+      .getNotes();
 
     assertEquals(1, notes.size());
     assertEquals(DEFAULT_LINK_AMOUNT, firsNoteWithAssignedLink.getLinks().size());
@@ -269,7 +311,9 @@ public class NoteLinksImplTest extends TestBase {
     createLinks(firsNoteWithAssignedLink.getId());
 
     List<Note> notes = getWithOk("/note-links/domain/" + NON_EXISTING_DOMAIN + "/type/" + PACKAGE_TYPE + "/id/" + PACKAGE_ID
-      + "?status=UNASSIGNED").as(NoteCollection.class).getNotes();
+      + "?status=UNASSIGNED")
+      .as(NoteCollection.class)
+      .getNotes();
 
     assertEquals(0, notes.size());
     assertEquals(DEFAULT_LINK_AMOUNT, firsNoteWithAssignedLink.getLinks().size());
@@ -283,7 +327,9 @@ public class NoteLinksImplTest extends TestBase {
     createLinks(firsNoteWithAssignedLink.getId());
 
     List<Note> notes = getWithOk("/note-links/domain/" + DOMAIN + "/type/" + PACKAGE_TYPE + "/id/" + PACKAGE_ID
-      + "?order=desc").as(NoteCollection.class).getNotes();
+      + "?order=desc")
+      .as(NoteCollection.class)
+      .getNotes();
 
     Note firstResultNote = getNoteById(notes, firsNoteWithAssignedLink.getId());
 
@@ -303,7 +349,9 @@ public class NoteLinksImplTest extends TestBase {
     createLinks(firsNoteWithAssignedLink.getId());
 
     List<Note> notes = getWithOk("/note-links/domain/" + DOMAIN + "/type/" + PACKAGE_TYPE + "/id/" + PACKAGE_ID
-      + "?order=asc").as(NoteCollection.class).getNotes();
+      + "?order=asc")
+      .as(NoteCollection.class)
+      .getNotes();
 
     Note firstResultNote = getNoteById(notes, firsNoteWithAssignedLink.getId());
 
@@ -322,8 +370,9 @@ public class NoteLinksImplTest extends TestBase {
     createNote();
     createLinks(firsNoteWithAssignedLink.getId());
 
-    final String response = getWithStatus("/note-links/domain/" + DOMAIN + "/type/" + PACKAGE_TYPE + "/id/" + PACKAGE_ID
-      + "?order=wrong", 400).asString();
+    final String response = getWithStatus("/note-links/domain/" + DOMAIN + "/type/" + PACKAGE_TYPE
+      + "/id/" + PACKAGE_ID + "?order=wrong", 400)
+      .asString();
 
     assertThat(response, containsString("Order is incorrect"));
   }
@@ -334,10 +383,24 @@ public class NoteLinksImplTest extends TestBase {
     createNote();
     createLinks(firsNoteWithAssignedLink.getId());
 
-    final String response = getWithStatus("/note-links/domain/" + DOMAIN + "/type/" + PACKAGE_TYPE + "/id/" + PACKAGE_ID
-      + "?status=wrong", 400).asString();
+    final String response = getWithStatus("/note-links/domain/" + DOMAIN + "/type/" + PACKAGE_TYPE
+      + "/id/" + PACKAGE_ID + "?status=wrong", 400)
+      .asString();
 
     assertThat(response, containsString("Status is incorrect"));
+  }
+
+  @Test
+  public void shouldReturn400WithErrorMessageWrongLimitAndOffset() {
+    Note firsNoteWithAssignedLink = createNote();
+    createNote();
+    createLinks(firsNoteWithAssignedLink.getId());
+
+    final String response = getWithStatus("/note-links/domain/" + DOMAIN + "/type/" + PACKAGE_TYPE
+      + "/id/" + PACKAGE_ID + "?limit=-1&offset=-1", 400)
+      .asString();
+
+    assertThat(response, containsString("parameter is incorrect"));
   }
 
   private void putLinks(NoteLinksPut requestBody) {

--- a/src/test/java/org/folio/rest/impl/NoteLinksImplTest.java
+++ b/src/test/java/org/folio/rest/impl/NoteLinksImplTest.java
@@ -1,18 +1,22 @@
 package org.folio.rest.impl;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.get;
-import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
-import static org.hamcrest.Matchers.containsString;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-
-import static org.folio.util.NoteTestData.NOTE_2;
-import static org.folio.util.NoteTestData.PACKAGE_ID;
-import static org.folio.util.NoteTestData.PACKAGE_TYPE;
-import static org.folio.util.NoteTestData.USER8;
-import static org.folio.util.TestUtil.readFile;
+import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
+import com.github.tomakehurst.wiremock.matching.EqualToPattern;
+import com.github.tomakehurst.wiremock.matching.UrlPathPattern;
+import io.vertx.core.json.Json;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.folio.rest.TestBase;
+import org.folio.rest.jaxrs.model.Link;
+import org.folio.rest.jaxrs.model.Note;
+import org.folio.rest.jaxrs.model.NoteCollection;
+import org.folio.rest.jaxrs.model.NoteLinkPut;
+import org.folio.rest.jaxrs.model.NoteLinksPut;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -20,24 +24,18 @@ import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
-import com.github.tomakehurst.wiremock.matching.EqualToPattern;
-import com.github.tomakehurst.wiremock.matching.UrlPathPattern;
-import io.vertx.core.json.Json;
-import io.vertx.ext.unit.TestContext;
-import io.vertx.ext.unit.junit.VertxUnitRunner;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-
-import org.folio.rest.TestBase;
-import org.folio.rest.jaxrs.model.Link;
-import org.folio.rest.jaxrs.model.Note;
-import org.folio.rest.jaxrs.model.NoteCollection;
-import org.folio.rest.jaxrs.model.NoteLinkPut;
-import org.folio.rest.jaxrs.model.NoteLinksPut;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static org.folio.util.NoteTestData.NOTE_2;
+import static org.folio.util.NoteTestData.PACKAGE_ID;
+import static org.folio.util.NoteTestData.PACKAGE_TYPE;
+import static org.folio.util.NoteTestData.USER8;
+import static org.folio.util.TestUtil.readFile;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(VertxUnitRunner.class)
 public class NoteLinksImplTest extends TestBase {
@@ -166,11 +164,11 @@ public class NoteLinksImplTest extends TestBase {
       .withLinks(Collections.singletonList(new Link()
         .withId(PACKAGE_ID)
         .withType(PACKAGE_TYPE)
-    ));
+      ));
     postNoteWithOk(Json.encode(note), USER8);
     removeLinks(note.getId());
     List<Note> notes = getNotes();
-    assertFalse(notes.stream().anyMatch(resultNote-> note.getId().equals(resultNote.getId())));
+    assertFalse(notes.stream().anyMatch(resultNote -> note.getId().equals(resultNote.getId())));
   }
 
   @Test
@@ -188,7 +186,7 @@ public class NoteLinksImplTest extends TestBase {
 
   @Test
   public void shouldReturnListOfNotesWithoutParameters() {
-    Note firstNote = createNote();
+    createNote();
     createNote();
 
     List<Note> notes = getWithOk("/note-links/domain/" + DOMAIN + "/type/" + PACKAGE_TYPE + "/id/123-456789")
@@ -196,7 +194,6 @@ public class NoteLinksImplTest extends TestBase {
       .getNotes();
 
     assertEquals(2, notes.size());
-    assertEquals(DEFAULT_LINK_AMOUNT, firstNote.getLinks().size());
   }
 
   @Test
@@ -235,7 +232,7 @@ public class NoteLinksImplTest extends TestBase {
 
   @Test
   public void shouldReturnAllRecordsOfNotesFromDBWithoutParametersAndWithNonExistingId() {
-    Note firstNote = createNote();
+    createNote();
     createNote();
 
     List<Note> notes = getWithOk(
@@ -244,25 +241,11 @@ public class NoteLinksImplTest extends TestBase {
       .getNotes();
 
     assertEquals(2, notes.size());
-    assertEquals(DEFAULT_LINK_AMOUNT, firstNote.getLinks().size());
-  }
-
-  @Test
-  public void shouldReturnAllRecordsOfNotesFromDBWithoutParametersAndWithInvalidId() {
-    Note firstNote = createNote();
-    createNote();
-
-    List<Note> notes = getWithOk("/note-links/domain/" + DOMAIN + "/type/" + PACKAGE_TYPE + "/id/" + INVALID_ID)
-      .as(NoteCollection.class)
-      .getNotes();
-
-    assertEquals(2, notes.size());
-    assertEquals(DEFAULT_LINK_AMOUNT, firstNote.getLinks().size());
   }
 
   @Test
   public void shouldReturnAllRecordsOfNotesFromDBWithoutParametersAndWithIncompleteUrl() {
-    Note firstNote = createNote();
+    createNote();
     createNote();
 
     List<Note> notes = getWithOk(
@@ -271,12 +254,12 @@ public class NoteLinksImplTest extends TestBase {
       .getNotes();
 
     assertEquals(2, notes.size());
-    assertEquals(DEFAULT_LINK_AMOUNT, firstNote.getLinks().size());
   }
 
   @Test
   public void shouldReturnListOfNotesWithAssignedStatus() {
     Note firstNote = createNote();
+    createNote();
     createLinks(firstNote.getId());
 
     List<Note> notes = getWithOk("/note-links/domain/" + DOMAIN + "/type/" + PACKAGE_TYPE + "/id/" + PACKAGE_ID
@@ -285,13 +268,12 @@ public class NoteLinksImplTest extends TestBase {
       .getNotes();
 
     assertEquals(1, notes.size());
-    assertEquals(DEFAULT_LINK_AMOUNT, firstNote.getLinks().size());
   }
 
   @Test
   public void shouldReturnListOfNotesWithUnassignedStatus() {
     Note firsNoteWithAssignedLink = createNote();
-    Note secondNoteWithUnassignedLink = createNote();
+    createNote();
     createLinks(firsNoteWithAssignedLink.getId());
 
     List<Note> notes = getWithOk("/note-links/domain/" + DOMAIN + "/type/" + PACKAGE_TYPE + "/id/" + PACKAGE_ID
@@ -300,8 +282,6 @@ public class NoteLinksImplTest extends TestBase {
       .getNotes();
 
     assertEquals(1, notes.size());
-    assertEquals(DEFAULT_LINK_AMOUNT, firsNoteWithAssignedLink.getLinks().size());
-    assertEquals(DEFAULT_LINK_AMOUNT, secondNoteWithUnassignedLink.getLinks().size());
   }
 
   @Test
@@ -310,14 +290,29 @@ public class NoteLinksImplTest extends TestBase {
     Note secondNoteWithUnassignedLink = createNote();
     createLinks(firsNoteWithAssignedLink.getId());
 
-    List<Note> notes = getWithOk("/note-links/domain/" + NON_EXISTING_DOMAIN + "/type/" + PACKAGE_TYPE + "/id/" + PACKAGE_ID
-      + "?status=UNASSIGNED")
+    List<Note> notes = getWithOk(
+      "/note-links/domain/" + NON_EXISTING_DOMAIN + "/type/" + PACKAGE_TYPE + "/id/" + PACKAGE_ID
+        + "?status=UNASSIGNED")
       .as(NoteCollection.class)
       .getNotes();
 
     assertEquals(0, notes.size());
     assertEquals(DEFAULT_LINK_AMOUNT, firsNoteWithAssignedLink.getLinks().size());
     assertEquals(DEFAULT_LINK_AMOUNT, secondNoteWithUnassignedLink.getLinks().size());
+  }
+
+  @Test
+  public void shouldReturnListOfNotesWithStatusAll() {
+    Note firsNoteWithAssignedLink = createNote();
+    createNote();
+    createLinks(firsNoteWithAssignedLink.getId());
+
+    List<Note> notes = getWithOk(
+      "/note-links/domain/" + DOMAIN + "/type/" + PACKAGE_TYPE + "/id/" + PACKAGE_ID + "?status=all")
+      .as(NoteCollection.class)
+      .getNotes();
+
+    assertEquals(2, notes.size());
   }
 
   @Test
@@ -335,7 +330,6 @@ public class NoteLinksImplTest extends TestBase {
 
     assertEquals(2, notes.size());
     assertEquals(secondNoteWithUnassignedLink.getId(), notes.get(0).getId());
-    assertEquals(DEFAULT_LINK_AMOUNT, notes.get(0).getLinks().size());
     assertEquals(2, notes.get(1).getLinks().size());
 
     assertEquals(PACKAGE_ID, firstResultNote.getLinks().get(1).getId());
@@ -343,13 +337,13 @@ public class NoteLinksImplTest extends TestBase {
   }
 
   @Test
-  public void shouldReturnListOfNotesWithOrderAscByStatus() {
+  public void shouldReturnListOfNotesWithOrderInUpper() {
     Note firsNoteWithAssignedLink = createNote();
     createNote();
     createLinks(firsNoteWithAssignedLink.getId());
 
-    List<Note> notes = getWithOk("/note-links/domain/" + DOMAIN + "/type/" + PACKAGE_TYPE + "/id/" + PACKAGE_ID
-      + "?order=asc")
+    List<Note> notes = getWithOk(
+      "/note-links/domain/" + DOMAIN + "/type/" + PACKAGE_TYPE + "/id/" + PACKAGE_ID + "?order=ASC")
       .as(NoteCollection.class)
       .getNotes();
 
@@ -357,7 +351,6 @@ public class NoteLinksImplTest extends TestBase {
 
     assertEquals(2, notes.size());
     assertEquals(firsNoteWithAssignedLink.getId(), notes.get(0).getId());
-    assertEquals(DEFAULT_LINK_AMOUNT, notes.get(1).getLinks().size());
     assertEquals(2, notes.get(0).getLinks().size());
 
     assertEquals(PACKAGE_ID, firstResultNote.getLinks().get(1).getId());


### PR DESCRIPTION
## Purpose
Regarding https://issues.folio.org/browse/MODNOTES-102
Implementing additional endpoint for GET notes by status and domain

## Approach
Adding new endpoint GET /note-links/domain/{domain}/type/{type}/id/{id}
Covering particular endpoint by tests.