### PR TITLE
Update to RMB25

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,11 +17,11 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.7</maven.compiler.source>
     <maven.compiler.target>1.7</maven.compiler.target>
-    <raml-module-builder.version>24.0.0</raml-module-builder.version>
+    <raml-module-builder.version>25.0.1</raml-module-builder.version>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
     <jsonschema_paths>types/**,raml-util/schemas</jsonschema_paths>
     <vertx-version>3.5.4</vertx-version>
-    <folio-service-tools.version>1.0.0</folio-service-tools.version>
+    <folio-service-tools.version>1.0.1</folio-service-tools.version>
   </properties>
 
   <repositories>

--- a/src/main/java/org/folio/db/CqlQuery.java
+++ b/src/main/java/org/folio/db/CqlQuery.java
@@ -3,10 +3,10 @@ package org.folio.db;
 import static org.folio.db.DbUtils.ALL_FIELDS;
 import static org.folio.db.DbUtils.getCQLWrapper;
 
+import org.folio.cql2pgjson.exception.FieldException;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.persist.cql.CQLWrapper;
 import org.folio.rest.persist.interfaces.Results;
-import org.z3950.zing.cql.cql2pgjson.FieldException;
 
 import io.vertx.core.Future;
 

--- a/src/main/java/org/folio/note/NoteRepositoryImpl.java
+++ b/src/main/java/org/folio/note/NoteRepositoryImpl.java
@@ -2,14 +2,17 @@ package org.folio.note;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import javax.ws.rs.NotFoundException;
 
+import org.apache.commons.lang3.StringUtils;
 import org.folio.db.CqlQuery;
 import org.folio.db.model.NoteView;
 import org.folio.rest.jaxrs.model.Note;
 import org.folio.rest.jaxrs.model.NoteCollection;
+import org.folio.rest.persist.PgUtil;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.persist.interfaces.Results;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -49,6 +52,11 @@ public class NoteRepositoryImpl implements NoteRepository {
   @Override
   public Future<Note> save(Note note, String tenantId) {
     Future<String> future = Future.future();
+
+    if (StringUtils.isBlank(note.getId())) {
+      note.setId(UUID.randomUUID().toString());
+    }
+
     PostgresClient.getInstance(vertx, tenantId)
       .save(NOTE_TABLE, note.getId(), note, future);
 

--- a/src/main/java/org/folio/rest/impl/NotesResourceImpl.java
+++ b/src/main/java/org/folio/rest/impl/NotesResourceImpl.java
@@ -16,7 +16,6 @@ import org.folio.rest.RestVerticle;
 import org.folio.rest.annotations.Validate;
 import org.folio.rest.jaxrs.model.Note;
 import org.folio.rest.jaxrs.resource.Notes;
-import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.tools.utils.TenantTool;
 import org.folio.spring.SpringContextUtil;
 import org.glassfish.jersey.internal.util.Producer;
@@ -33,7 +32,6 @@ import io.vertx.core.logging.LoggerFactory;
 
 public class NotesResourceImpl implements Notes {
   private static final String LOCATION_PREFIX = "/notes/";
-  private static final String IDFIELDNAME = "id";
   private final Logger logger = LoggerFactory.getLogger("mod-notes");
 
   @Autowired
@@ -44,7 +42,6 @@ public class NotesResourceImpl implements Notes {
   // Get this from the restVerticle, like the rest, when it gets defined there.
   public NotesResourceImpl(Vertx vertx, String tenantId) {
     SpringContextUtil.autowireDependencies(this, vertx.getOrCreateContext());
-    PostgresClient.getInstance(vertx, tenantId).setIdField(IDFIELDNAME);
   }
 
   @Override

--- a/src/main/java/org/folio/type/NoteTypeRepositoryImpl.java
+++ b/src/main/java/org/folio/type/NoteTypeRepositoryImpl.java
@@ -6,7 +6,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 
+import org.apache.commons.lang3.StringUtils;
 import org.folio.db.CqlQuery;
 import org.folio.rest.jaxrs.model.NoteType;
 import org.folio.rest.jaxrs.model.NoteTypeCollection;
@@ -68,6 +70,10 @@ public class NoteTypeRepositoryImpl implements NoteTypeRepository {
   public Future<NoteType> save(NoteType entity, String tenantId) {
     Future<String> future = Future.future(); // future with id as result
 
+    if (StringUtils.isBlank(entity.getId())) {
+      entity.setId(UUID.randomUUID().toString());
+    }
+
     pgClient(tenantId).save(NOTE_TYPE_TABLE, entity.getId(), entity, future);
 
     return future.map(id -> updateId(entity, id)); // update id only, copy the rest from the original entity
@@ -92,9 +98,7 @@ public class NoteTypeRepositoryImpl implements NoteTypeRepository {
   }
 
   private PostgresClient pgClient(String tenantId) {
-    PostgresClient pg = PostgresClient.getInstance(vertx, tenantId);
-    pg.setIdField("id");
-    return pg;
+    return PostgresClient.getInstance(vertx, tenantId);
   }
 
   private NoteTypeCollection toNoteTypeCollection(Results<NoteType> results) {

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -4,8 +4,6 @@
       "tableName": "note_data",
       "fromModuleVersion": 0.2,
       "withMetadata": true,
-      "generateId": true,
-      "populateJsonWithId": true,
       "likeIndex": [
         {
           "fieldName": "title",
@@ -16,10 +14,8 @@
     },
     {
       "tableName": "note_type",
-      "generateId": true,
       "fromModuleVersion": 1.0,
       "withMetadata": true,
-      "populateJsonWithId": true,
       "uniqueIndex" : [
         {
           "fieldName" : "name",

--- a/src/test/java/org/folio/rest/impl/NotesTest.java
+++ b/src/test/java/org/folio/rest/impl/NotesTest.java
@@ -343,7 +343,7 @@ public class NotesTest extends TestBase {
   public void shouldFindNoteByPartialUserId() {
     postNoteWithOk(NOTE_1, USER9);
 
-    final String response = getWithOk("/notes?query=metadata.createdByUserId=*9999*").asString();
+    final String response = getWithOk("/notes?query=metadata.createdByUserId=9999*").asString();
     assertThat(response, containsString("First note"));
   }
 


### PR DESCRIPTION
## Purpose
Update to RMB 25

## Approach
Updated POM dependency for RMB to `25.0.1`
Updated POM dependency for folio-service-tools to `1.0.1`. The old `1.0.0` uses RMB24.
Update two places to fill UUID before saving the entity because RMB 25 does not handle that anymore.
Adjust one test case because RMB25 does not support left truncation search anymore.

#### Open Questions
Rather than asking all modules to fill UUID, maybe we can handle it in one place like `RMB PostgresClient save` method.
The loss of left truncation search could be inconvenient for customers.

## Learning
N/A