### PR TITLE
MODKBEKBJ-289 Support sort by link number

### DIFF
--- a/src/main/java/org/folio/links/NoteLinksConstants.java
+++ b/src/main/java/org/folio/links/NoteLinksConstants.java
@@ -42,6 +42,8 @@ class NoteLinksConstants {
 
   static final String ORDER_BY_TITLE_CLAUSE = "ORDER BY jsonb->>'title' %s ";
 
+  static final String ORDER_BY_LINKS_NUMBER = "ORDER BY json_array_length((jsonb->>'links')::json) %s ";
+
   static final String LIMIT_OFFSET = "LIMIT ? OFFSET ? ";
 
   static final String SELECT_NOTES_BY_DOMAIN_AND_TITLE =

--- a/src/main/java/org/folio/links/NoteLinksRepositoryImpl.java
+++ b/src/main/java/org/folio/links/NoteLinksRepositoryImpl.java
@@ -8,6 +8,7 @@ import static org.folio.links.NoteLinksConstants.HAS_LINK_CONDITION;
 import static org.folio.links.NoteLinksConstants.INSERT_LINKS;
 import static org.folio.links.NoteLinksConstants.LIMIT_OFFSET;
 import static org.folio.links.NoteLinksConstants.NOTE_TABLE;
+import static org.folio.links.NoteLinksConstants.ORDER_BY_LINKS_NUMBER;
 import static org.folio.links.NoteLinksConstants.ORDER_BY_STATUS_CLAUSE;
 import static org.folio.links.NoteLinksConstants.ORDER_BY_TITLE_CLAUSE;
 import static org.folio.links.NoteLinksConstants.REMOVE_LINKS;
@@ -271,6 +272,8 @@ public class NoteLinksRepositoryImpl implements NoteLinksRepository {
     if (orderBy == OrderBy.STATUS) {
       query.append(String.format(ORDER_BY_STATUS_CLAUSE, order.toString()));
       parameters.add(jsonLink);
+    } else if (orderBy == OrderBy.LINKSNUMBER) {
+      query.append(String.format(ORDER_BY_LINKS_NUMBER, order.toString()));
     } else {
       query.append(String.format(ORDER_BY_TITLE_CLAUSE, order.toString()));
     }

--- a/src/main/java/org/folio/model/OrderBy.java
+++ b/src/main/java/org/folio/model/OrderBy.java
@@ -6,7 +6,7 @@ import org.apache.commons.lang3.EnumUtils;
 
 public enum OrderBy {
 
-  STATUS("status"), TITLE("title");
+  STATUS("status"), TITLE("title"), LINKSNUMBER("linksNumber");
 
   private String value;
 

--- a/src/test/java/org/folio/rest/impl/NoteLinksImplTest.java
+++ b/src/test/java/org/folio/rest/impl/NoteLinksImplTest.java
@@ -322,6 +322,42 @@ public class NoteLinksImplTest extends TestBase {
   }
 
   @Test
+  public void shouldReturnListOfNotesSortedByLinkNumberAsc() {
+    Note firstNote = getNote().withTitle("ABC");
+    Note secondNote = getNote().withTitle("ZZZ");
+    postNoteWithOk(Json.encode(firstNote), USER8);
+    postNoteWithOk(Json.encode(secondNote), USER8);
+    createLinks(firstNote.getId());
+
+    List<Note> notes = getWithOk("/note-links/domain/" + DOMAIN + "/type/" + PACKAGE_TYPE + "/id/" + PACKAGE_ID
+      + "?order=asc&orderBy=linksNumber")
+      .as(NoteCollection.class)
+      .getNotes();
+
+    assertEquals(2, notes.size());
+    assertEquals(secondNote.getTitle(), notes.get(0).getTitle());
+    assertEquals(firstNote.getTitle(), notes.get(1).getTitle());
+  }
+
+  @Test
+  public void shouldReturnListOfNotesSortedByLinkNumberDesc() {
+    Note firstNote = getNote().withTitle("ABC");
+    Note secondNote = getNote().withTitle("ZZZ");
+    postNoteWithOk(Json.encode(firstNote), USER8);
+    postNoteWithOk(Json.encode(secondNote), USER8);
+    createLinks(firstNote.getId());
+
+    List<Note> notes = getWithOk("/note-links/domain/" + DOMAIN + "/type/" + PACKAGE_TYPE + "/id/" + PACKAGE_ID
+      + "?order=desc&orderBy=linksNumber")
+      .as(NoteCollection.class)
+      .getNotes();
+
+    assertEquals(2, notes.size());
+    assertEquals(firstNote.getTitle(), notes.get(0).getTitle());
+    assertEquals(secondNote.getTitle(), notes.get(1).getTitle());
+  }
+
+  @Test
   public void shouldReturnListOfNotesSearchedByTitle() {
     Note firstNote = getNote().withTitle("Title ABC");
     Note secondNote = getNote().withTitle("Title ZZZ ABC");


### PR DESCRIPTION
## Purpose
Support sort by link number

## Approach
Use json_array_length function in postgres to sort notes by the size of "links" array.