### PR TITLE
MODNOTES-100  Fix error message when we try to delete a note type

### DIFF
--- a/src/main/java/org/folio/spring/config/ApplicationConfig.java
+++ b/src/main/java/org/folio/spring/config/ApplicationConfig.java
@@ -4,6 +4,8 @@ import static org.folio.rest.exc.ExceptionPredicates.instanceOf;
 import static org.folio.rest.exc.RestExceptionHandlers.badRequestHandler;
 import static org.folio.rest.exc.RestExceptionHandlers.baseBadRequestHandler;
 import static org.folio.rest.exc.RestExceptionHandlers.baseNotFoundHandler;
+import static org.folio.rest.exc.RestExceptionHandlers.baseUnauthorizedHandler;
+import static org.folio.rest.exc.RestExceptionHandlers.baseUnprocessableHandler;
 import static org.folio.rest.exc.RestExceptionHandlers.completionCause;
 import static org.folio.rest.exc.RestExceptionHandlers.generalHandler;
 import static org.folio.rest.exc.RestExceptionHandlers.logged;
@@ -59,6 +61,8 @@ public class ApplicationConfig {
   public PartialFunction<Throwable, Response> noteTypesExcHandler() {
     return logged(baseBadRequestHandler()
       .orElse(baseNotFoundHandler())
+      .orElse(baseUnauthorizedHandler())
+      .orElse(baseUnprocessableHandler())
       .orElse(generalHandler())
       .compose(completionCause())); // extract the cause before applying any handler
   }

--- a/src/main/java/org/folio/spring/config/ApplicationConfig.java
+++ b/src/main/java/org/folio/spring/config/ApplicationConfig.java
@@ -22,6 +22,8 @@ import org.springframework.core.io.ClassPathResource;
 
 import org.folio.common.pf.PartialFunction;
 import org.folio.config.ModConfiguration;
+import org.folio.db.exc.translation.DBExceptionTranslator;
+import org.folio.db.exc.translation.DBExceptionTranslatorFactory;
 import org.folio.rest.tools.messages.Messages;
 
 @Configuration
@@ -68,6 +70,12 @@ public class ApplicationConfig {
       .orElse(baseNotFoundHandler())
       .orElse(generalHandler())
       .compose(completionCause())); // extract the cause before applying any handler
+  }
+
+  @Bean
+  public DBExceptionTranslator excTranslator(@Value("${db.exception.translator.name}") String translatorName) {
+    DBExceptionTranslatorFactory factory = DBExceptionTranslatorFactory.instance();
+    return factory.create(translatorName);
   }
 
   @Bean

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,4 @@
+db.exception.translator.name=postgresql
 note.configuration.module=NOTES
 note.types.number.limit.default=25
 note.types.default.name=General note


### PR DESCRIPTION
## Purpose
Per [MODNOTES-100](https://issues.folio.org/browse/MODNOTES-100), fix error message when we try to delete a note type.

## Approach
- use db exception translation to narrow generic db exception to FK violation
- handle FK violation in case of delete to customize the message 

