### PR TITLE
MODNOTES-100 change the message

### DIFF
--- a/src/main/java/org/folio/type/NoteTypeServiceImpl.java
+++ b/src/main/java/org/folio/type/NoteTypeServiceImpl.java
@@ -139,7 +139,7 @@ public class NoteTypeServiceImpl implements NoteTypeService {
       Throwable exc = t;
 
       if (DbExcUtils.isFKViolation(t)) {
-        exc = new BadRequestException("Note type is referenced by note(s) and cannot be deleted");
+        exc = new BadRequestException("Note type is assigned to a note(s) and cannot be deleted");
       }
 
       return Future.failedFuture(exc);

--- a/src/test/java/org/folio/rest/impl/NoteTypesImplTest.java
+++ b/src/test/java/org/folio/rest/impl/NoteTypesImplTest.java
@@ -607,7 +607,7 @@ public class NoteTypesImplTest extends TestBase {
       DBTestUtil.insertNote(vertx, note.getId(), STUB_TENANT, toJson(note));
 
       String response = deleteWithStatus(NOTE_TYPES_ENDPOINT + "/" + noteType.getId(), SC_BAD_REQUEST).asString();
-      assertThat(response, is("Note type is referenced by note(s) and cannot be deleted"));
+      assertThat(response, is("Note type is assigned to a note(s) and cannot be deleted"));
     } finally {
       DBTestUtil.deleteAllNotes(vertx);
       DBTestUtil.deleteAllNoteTypes(vertx);


### PR DESCRIPTION
## Purpose
Change the text of error message 
- from "Note type is referenced by note(s) and cannot be deleted"
- to "Note type is assigned to a note(s) and cannot be deleted"