### PR TITLE
MODNOTES-117: Remove dangerous html tags from note content

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
     <aspectj.version>1.9.1</aspectj.version>
     <folio-service-tools.version>1.1.0</folio-service-tools.version>
     <jackson-databind.version>2.9.9.2</jackson-databind.version>
+    <spring.version>5.1.1.RELEASE</spring.version>
   </properties>
 
   <repositories>
@@ -99,6 +100,12 @@
       <version>1.0.0</version>
     </dependency>
     <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-test</artifactId>
+      <version>${spring.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.folio</groupId>
       <artifactId>folio-service-tools-dev</artifactId>
       <version>${folio-service-tools.version}</version>
@@ -143,6 +150,11 @@
       <groupId>io.vertx</groupId>
       <artifactId>vertx-web</artifactId>
       <version>${vertx-version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jsoup</groupId>
+      <artifactId>jsoup</artifactId>
+      <version>1.12.1</version>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>

--- a/src/main/java/org/folio/note/NoteServiceImpl.java
+++ b/src/main/java/org/folio/note/NoteServiceImpl.java
@@ -39,6 +39,9 @@ public class NoteServiceImpl implements NoteService {
 
   @Override
   public Future<Note> addNote(Note note, OkapiParams okapiParams) {
+    logger.debug("Removing unsafe tags");
+    note.setContent(sanitizeHtml(note.getContent()));
+    logger.debug("Create note with content: {}", Json.encode(note));
     final List<Link> links = note.getLinks();
     if (Objects.isNull(links) || links.isEmpty()) {
       return failedFuture(new InputValidationException("links", "links", "At least one link should be present"));
@@ -70,6 +73,8 @@ public class NoteServiceImpl implements NoteService {
 
   @Override
   public Future<Void> updateNote(String id, Note note, OkapiParams okapiParams) {
+    logger.debug("Removing unsafe tags");
+    note.setContent(sanitizeHtml(note.getContent()));
     logger.debug("PUT note with id:{} and content: {}", id, Json.encode(note));
     if (note.getId() == null) {
       note.setId(id);
@@ -79,7 +84,7 @@ public class NoteServiceImpl implements NoteService {
     if (!note.getId().equals(id)) {
       return failedFuture(new InputValidationException("id", note.getId(), "Can not change Id"));
     }
-    note.setContent(sanitizeHtml(note.getContent()));
+
 
     return userLookUpService.getUserInfo(okapiParams.getHeadersAsMap())
       .compose(userLookUp -> {

--- a/src/main/java/org/folio/spring/config/ApplicationConfig.java
+++ b/src/main/java/org/folio/spring/config/ApplicationConfig.java
@@ -14,7 +14,11 @@ import static org.folio.rest.exceptions.NoteExceptionHandlers.entityValidationHa
 import javax.ws.rs.NotAuthorizedException;
 import javax.ws.rs.core.Response;
 
-import com.rits.cloning.Cloner;
+import org.folio.common.pf.PartialFunction;
+import org.folio.config.ModConfiguration;
+import org.folio.db.exc.translation.DBExceptionTranslator;
+import org.folio.db.exc.translation.DBExceptionTranslatorFactory;
+import org.folio.rest.tools.messages.Messages;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
@@ -22,17 +26,14 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
 import org.springframework.core.io.ClassPathResource;
 
-import org.folio.common.pf.PartialFunction;
-import org.folio.config.ModConfiguration;
-import org.folio.db.exc.translation.DBExceptionTranslator;
-import org.folio.db.exc.translation.DBExceptionTranslatorFactory;
-import org.folio.rest.tools.messages.Messages;
+import com.rits.cloning.Cloner;
 
 @Configuration
 @ComponentScan(basePackages = {
   "org.folio.type",
   "org.folio.note",
-  "org.folio.links"})
+  "org.folio.links",
+  "org.folio.userlookup"})
 public class ApplicationConfig {
 
   @Bean

--- a/src/main/java/org/folio/type/NoteTypeServiceImpl.java
+++ b/src/main/java/org/folio/type/NoteTypeServiceImpl.java
@@ -8,21 +8,22 @@ import java.util.function.Function;
 
 import javax.ws.rs.BadRequestException;
 
-import com.rits.cloning.Cloner;
-import io.vertx.core.CompositeFuture;
-import io.vertx.core.Future;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Component;
-
 import org.folio.common.OkapiParams;
 import org.folio.config.Configuration;
 import org.folio.db.exc.DbExcUtils;
 import org.folio.rest.jaxrs.model.NoteType;
 import org.folio.rest.jaxrs.model.NoteTypeCollection;
 import org.folio.service.exc.ServiceExceptions;
-import org.folio.userlookup.UserLookUp;
+import org.folio.userlookup.UserLookUpService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import com.rits.cloning.Cloner;
+
+import io.vertx.core.CompositeFuture;
+import io.vertx.core.Future;
 
 @Component
 public class NoteTypeServiceImpl implements NoteTypeService {
@@ -31,6 +32,8 @@ public class NoteTypeServiceImpl implements NoteTypeService {
 
   @Autowired
   private NoteTypeRepository repository;
+  @Autowired
+  private UserLookUpService userLookUpService;
   @Autowired
   private Configuration configuration;
   @Autowired @Qualifier("restModelCloner")
@@ -102,7 +105,7 @@ public class NoteTypeServiceImpl implements NoteTypeService {
   }
 
   private Future<NoteType> populateCreator(NoteType entity, OkapiParams params) {
-    return UserLookUp.getUserInfo(params.getHeadersAsMap()).map(user -> {
+    return userLookUpService.getUserInfo(params.getHeadersAsMap()).map(user -> {
       if (entity.getMetadata() == null) {
         return entity;
       }
@@ -115,7 +118,7 @@ public class NoteTypeServiceImpl implements NoteTypeService {
   }
 
   private Future<NoteType> populateUpdater(NoteType entity, OkapiParams params) {
-    return UserLookUp.getUserInfo(params.getHeadersAsMap()).map(user -> {
+    return userLookUpService.getUserInfo(params.getHeadersAsMap()).map(user -> {
       if (entity.getMetadata() == null) {
         return entity;
       }

--- a/src/main/java/org/folio/userlookup/UserLookUp.java
+++ b/src/main/java/org/folio/userlookup/UserLookUp.java
@@ -1,40 +1,18 @@
 package org.folio.userlookup;
 
-import java.util.Map;
-
-import javax.ws.rs.BadRequestException;
-import javax.ws.rs.NotAuthorizedException;
-import javax.ws.rs.NotFoundException;
-
-import io.vertx.core.Future;
-import io.vertx.core.http.CaseInsensitiveHeaders;
-import io.vertx.core.json.JsonObject;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import org.folio.okapi.common.XOkapiHeaders;
-import org.folio.rest.RestVerticle;
-import org.folio.rest.tools.client.HttpClientFactory;
-import org.folio.rest.tools.client.Response;
-import org.folio.rest.tools.client.interfaces.HttpClientInterface;
-import org.folio.rest.tools.utils.TenantTool;
+import lombok.Builder;
 
 /**
  * Retrieves user information from mod-users /users/{userId} endpoint.
  */
+@Builder
 public class UserLookUp {
-  private static final Logger logger = LoggerFactory.getLogger(UserLookUp.class);
-
   private String userName;
   private String firstName;
   private String middleName;
   private String lastName;
 
-  private UserLookUp() {
-    super();
-  }
-
- /**
+  /**
    * Returns the username.
    *
    * @return UserName.
@@ -73,80 +51,6 @@ public class UserLookUp {
   @Override
   public String toString() {
     return "UserInfo [userName=" + userName
-        + ", firstName=" + firstName + ", middleName=" + middleName + ", lastName=" + lastName + ']';
-  }
-
-  /**
-   * Returns the user information for the userid specified in the original
-   * request.
-   *
-   * @param okapiHeaders The headers for the current API call.
-   * @return User information based on userid from header.
-   */
-  public static Future<UserLookUp> getUserInfo(final Map<String, String> okapiHeaders) {
-    CaseInsensitiveHeaders headers = new CaseInsensitiveHeaders();
-    headers.addAll(okapiHeaders);
-
-    final String tenantId = TenantTool.calculateTenantId(headers.get(RestVerticle.OKAPI_HEADER_TENANT));
-    final String userId = headers.get(RestVerticle.OKAPI_USERID_HEADER);
-    Future<UserLookUp> future = Future.future();
-    if (userId == null) {
-      logger.error("No userid header");
-      future.fail(new BadRequestException("Missing user id header, cannot look up user"));
-      return future;
-    }
-
-    String okapiURL = headers.get(XOkapiHeaders.URL);
-    String url = "/users/" + userId;
-    try {
-      final HttpClientInterface httpClient = HttpClientFactory.getHttpClient(okapiURL, tenantId);
-      httpClient.request(url, okapiHeaders)
-        .thenApply(response -> {
-          try {
-            if (Response.isSuccess(response.getCode())) {
-                return mapUserInfo(response);
-            } else if (response.getCode() == 401 || response.getCode() == 403) {
-                logger.error("Authorization failure");
-                throw new NotAuthorizedException("Authorization failure");
-            } else if (response.getCode() == 404) {
-                logger.error("User not found");
-                throw new NotFoundException("User not found");
-            } else {
-                logger.error("Cannot get user data: " + response.getError().toString(), response.getException());
-                 throw new IllegalStateException(response.getError().toString());
-            }
-          } finally {
-            httpClient.closeClient();
-          }
-        })
-        .thenAccept(future::complete)
-        .exceptionally(e -> {
-          future.fail(e.getCause());
-          return null;
-        });
-    } catch (Exception e) {
-      logger.error("Cannot get user data: " + e.getMessage(), e);
-      future.fail(e);
-    }
-
-    return future;
-  }
-
-  private static UserLookUp mapUserInfo(Response response) {
-    UserLookUp userInfo = new UserLookUp();
-    JsonObject user = response.getBody();
-    if (user.containsKey("username") && user.containsKey("personal")) {
-      userInfo.userName = user.getString("username");
-
-      JsonObject personalInfo = user.getJsonObject("personal");
-      if (personalInfo != null) {
-        userInfo.firstName = personalInfo.getString("firstName");
-        userInfo.middleName = personalInfo.getString("middleName");
-        userInfo.lastName = personalInfo.getString("lastName");
-      }
-    } else {
-      throw new BadRequestException("Missing fields");
-    }
-    return userInfo;
+      + ", firstName=" + firstName + ", middleName=" + middleName + ", lastName=" + lastName + ']';
   }
 }

--- a/src/main/java/org/folio/userlookup/UserLookUpService.java
+++ b/src/main/java/org/folio/userlookup/UserLookUpService.java
@@ -1,0 +1,100 @@
+package org.folio.userlookup;
+
+import java.util.Map;
+
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.NotAuthorizedException;
+import javax.ws.rs.NotFoundException;
+
+import org.folio.okapi.common.XOkapiHeaders;
+import org.folio.rest.RestVerticle;
+import org.folio.rest.tools.client.HttpClientFactory;
+import org.folio.rest.tools.client.Response;
+import org.folio.rest.tools.client.interfaces.HttpClientInterface;
+import org.folio.rest.tools.utils.TenantTool;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import io.vertx.core.Future;
+import io.vertx.core.http.CaseInsensitiveHeaders;
+import io.vertx.core.json.JsonObject;
+
+@Component
+public class UserLookUpService {
+
+  private static final Logger logger = LoggerFactory.getLogger(UserLookUp.class);
+  /**
+   * Returns the user information for the userid specified in the original
+   * request.
+   *
+   * @param okapiHeaders The headers for the current API call.
+   * @return User information based on userid from header.
+   */
+  public Future<UserLookUp> getUserInfo(final Map<String, String> okapiHeaders) {
+    CaseInsensitiveHeaders headers = new CaseInsensitiveHeaders();
+    headers.addAll(okapiHeaders);
+
+    final String tenantId = TenantTool.calculateTenantId(headers.get(RestVerticle.OKAPI_HEADER_TENANT));
+    final String userId = headers.get(RestVerticle.OKAPI_USERID_HEADER);
+    Future<UserLookUp> future = Future.future();
+    if (userId == null) {
+      logger.error("No userid header");
+      future.fail(new BadRequestException("Missing user id header, cannot look up user"));
+      return future;
+    }
+
+    String okapiURL = headers.get(XOkapiHeaders.URL);
+    String url = "/users/" + userId;
+    try {
+      final HttpClientInterface httpClient = HttpClientFactory.getHttpClient(okapiURL, tenantId);
+      httpClient.request(url, okapiHeaders)
+        .thenApply(response -> {
+          try {
+            if (Response.isSuccess(response.getCode())) {
+              return mapUserInfo(response);
+            } else if (response.getCode() == 401 || response.getCode() == 403) {
+              logger.error("Authorization failure");
+              throw new NotAuthorizedException("Authorization failure");
+            } else if (response.getCode() == 404) {
+              logger.error("User not found");
+              throw new NotFoundException("User not found");
+            } else {
+              logger.error("Cannot get user data: " + response.getError().toString(), response.getException());
+              throw new IllegalStateException(response.getError().toString());
+            }
+          } finally {
+            httpClient.closeClient();
+          }
+        })
+        .thenAccept(future::complete)
+        .exceptionally(e -> {
+          future.fail(e.getCause());
+          return null;
+        });
+    } catch (Exception e) {
+      logger.error("Cannot get user data: " + e.getMessage(), e);
+      future.fail(e);
+    }
+
+    return future;
+  }
+
+  private UserLookUp mapUserInfo(Response response) {
+    UserLookUp.UserLookUpBuilder builder = UserLookUp.builder();
+    JsonObject user = response.getBody();
+    if (user.containsKey("username") && user.containsKey("personal")) {
+      builder.userName(user.getString("username"));
+
+      JsonObject personalInfo = user.getJsonObject("personal");
+      if (personalInfo != null) {
+        builder.firstName(personalInfo.getString("firstName"));
+        builder.middleName(personalInfo.getString("middleName"));
+        builder.lastName(personalInfo.getString("lastName"));
+      }
+    } else {
+      throw new BadRequestException("Missing fields");
+    }
+    return builder.build();
+  }
+}

--- a/src/test/java/org/folio/note/NoteServiceImplTest.java
+++ b/src/test/java/org/folio/note/NoteServiceImplTest.java
@@ -1,0 +1,83 @@
+package org.folio.note;
+
+import static org.folio.util.NoteTestData.NOTE_1;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.folio.common.OkapiParams;
+import org.folio.rest.jaxrs.model.Metadata;
+import org.folio.rest.jaxrs.model.Note;
+import org.folio.spring.config.TestConfig;
+import org.folio.userlookup.UserLookUp;
+import org.folio.userlookup.UserLookUpService;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import io.vertx.core.Future;
+import io.vertx.core.json.Json;
+
+@RunWith(SpringRunner.class)
+@ContextConfiguration(classes = TestConfig.class)
+public class NoteServiceImplTest {
+
+  @Autowired
+  @InjectMocks
+  NoteServiceImpl noteService;
+  @Mock
+  NoteRepositoryImpl repository;
+  @Mock
+  UserLookUpService userLookUpService;
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.initMocks(this);
+  }
+
+  @Test
+  public void shouldSanitizeInputOnAdd() {
+    Note note = Json.decodeValue(NOTE_1, Note.class)
+      .withContent("<script></script><img/><br><iframe></iframe>")
+      .withMetadata(new Metadata());
+
+    ArgumentCaptor<Note> captor = ArgumentCaptor.forClass(Note.class);
+    when(userLookUpService.getUserInfo(any())).thenReturn(Future.succeededFuture(UserLookUp.builder().build()));
+    when(repository.save(captor.capture(), any())).thenReturn(Future.succeededFuture(note));
+
+    noteService.addNote(note, mock(OkapiParams.class));
+
+    assertThat(captor.getValue().getContent(), not(containsString("<script>")));
+    assertThat(captor.getValue().getContent(), not(containsString("<img/>")));
+    assertThat(captor.getValue().getContent(), not(containsString("<iframe>")));
+    assertThat(captor.getValue().getContent(), containsString("<br>"));
+  }
+
+  @Test
+  public void shouldSanitizeInputOnUpdate() {
+    Note note = Json.decodeValue(NOTE_1, Note.class)
+      .withContent("<script></script><br><iframe></iframe>")
+      .withMetadata(new Metadata());
+
+    ArgumentCaptor<Note> captor = ArgumentCaptor.forClass(Note.class);
+    when(userLookUpService.getUserInfo(any())).thenReturn(Future.succeededFuture(UserLookUp.builder().build()));
+    when(repository.update(eq(note.getId()), captor.capture(), any())).thenReturn(Future.succeededFuture());
+
+    noteService.updateNote(note.getId(), note, mock(OkapiParams.class));
+
+    assertThat(captor.getValue().getContent(), not(containsString("<script>")));
+    assertThat(captor.getValue().getContent(), not(containsString("<iframe>")));
+    assertThat(captor.getValue().getContent(), containsString("<br>"));
+  }
+}

--- a/src/test/java/org/folio/userlookup/UserLookUpTest.java
+++ b/src/test/java/org/folio/userlookup/UserLookUpTest.java
@@ -11,25 +11,26 @@ import java.util.Map;
 import javax.ws.rs.NotAuthorizedException;
 import javax.ws.rs.NotFoundException;
 
+import org.folio.okapi.common.XOkapiHeaders;
+import org.folio.rest.TestBase;
+import org.folio.test.junit.TestStartLoggingRule;
+import org.folio.test.util.TestUtil;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+import org.junit.runner.RunWith;
+
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
 import com.github.tomakehurst.wiremock.common.Slf4jNotifier;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.github.tomakehurst.wiremock.matching.RegexPattern;
 import com.github.tomakehurst.wiremock.matching.UrlPathPattern;
+
 import io.vertx.core.Future;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestRule;
-import org.junit.runner.RunWith;
-
-import org.folio.okapi.common.XOkapiHeaders;
-import org.folio.rest.TestBase;
-import org.folio.test.junit.TestStartLoggingRule;
-import org.folio.test.util.TestUtil;
 
 @RunWith(VertxUnitRunner.class)
 public class UserLookUpTest {
@@ -39,6 +40,8 @@ public class UserLookUpTest {
   private final String GET_USER_ENDPOINT = "/users/";
   private static final String USER_INFO_STUB_FILE = "responses/userlookup/mock_user_response_200.json";
 
+  private UserLookUpService userLookUpService = new UserLookUpService();
+
   @Rule
   public TestRule watcher = TestStartLoggingRule.instance();
 
@@ -47,6 +50,7 @@ public class UserLookUpTest {
     WireMockConfiguration.wireMockConfig()
       .dynamicPort()
       .notifier(new Slf4jNotifier(true)));
+
 
   @Test
   public void shouldReturn200WhenUserIdIsValid(TestContext context) throws IOException, URISyntaxException {
@@ -63,7 +67,7 @@ public class UserLookUpTest {
         .willReturn(new ResponseDefinitionBuilder()
             .withBody(TestUtil.readFile(USER_INFO_STUB_FILE))));
 
-    Future<UserLookUp> info = UserLookUp.getUserInfo(okapiHeaders);
+    Future<UserLookUp> info = userLookUpService.getUserInfo(okapiHeaders);
     info.compose(userInfo -> {
       context.assertNotNull(userInfo);
 
@@ -97,7 +101,7 @@ public class UserLookUpTest {
             .withStatus(401)
             .withStatusMessage("Authorization Failure")));
 
-    Future<UserLookUp> info = UserLookUp.getUserInfo(okapiHeaders);
+    Future<UserLookUp> info = userLookUpService.getUserInfo(okapiHeaders);
     info.compose(result -> {
       context.assertNull(result);
       async.complete();
@@ -125,7 +129,7 @@ public class UserLookUpTest {
             .withStatus(404)
             .withStatusMessage("User Not Found")));
 
-    Future<UserLookUp> info = UserLookUp.getUserInfo(okapiHeaders);
+    Future<UserLookUp> info = userLookUpService.getUserInfo(okapiHeaders);
     info.compose(result -> {
       context.assertNull(result);
       async.complete();
@@ -143,7 +147,7 @@ public class UserLookUpTest {
 
     okapiHeaders.put(XOkapiHeaders.TENANT, STUB_TENANT);
 
-    Future<UserLookUp> info = UserLookUp.getUserInfo(okapiHeaders);
+    Future<UserLookUp> info = userLookUpService.getUserInfo(okapiHeaders);
     info.compose(result -> {
       context.assertNull(result);
       async.complete();


### PR DESCRIPTION
## Purpose
Sanitize user html input

## Approach
Use Jsoup to remove dangerous tags.
Move UserLookUp functionality to a separate service to make it mockable
in unit tests.

## Learning
Jsoup is a library that can parse HTML and among other things, delete all tags that are not specified in whitelist of safe tags
https://jsoup.org