### PR TITLE
MODNOTES-128: Update RMB to 27.0.0 to use "snippetPath" schema attribute

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <raml-module-builder.version>25.0.1</raml-module-builder.version>
+    <raml-module-builder.version>27.0.0</raml-module-builder.version>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
     <jsonschema_paths>types/**,raml-util/schemas</jsonschema_paths>
     <vertx-version>3.5.4</vertx-version>

--- a/src/main/resources/templates/db_scripts/create_note_type_view.sql
+++ b/src/main/resources/templates/db_scripts/create_note_type_view.sql
@@ -1,9 +1,10 @@
-SELECT note_type.id,
-    jsonb_build_object('id', note_type.jsonb ->> 'id'::text,
-    'name', note_type.jsonb ->> 'name'::text,
-    'usage', json_build_object('noteTotal', count(note_data.jsonb ->> 'id'::text)),
-    'metadata', note_type.jsonb -> 'metadata'::text)
-    AS jsonb
-    FROM diku_mod_notes.note_type
-    LEFT JOIN diku_mod_notes.note_data ON (note_data.jsonb ->> 'typeId'::text) = (note_type.jsonb ->> 'id'::text)
+CREATE OR REPLACE VIEW note_type_view AS
+  SELECT note_type.id, jsonb_build_object(
+  'id', note_type.jsonb ->> 'id'::text,
+  'name', note_type.jsonb ->> 'name'::text,
+  'usage', json_build_object('noteTotal', count(note_data.jsonb ->> 'id'::text)),
+  'metadata', note_type.jsonb -> 'metadata'::text)
+  AS jsonb
+  FROM note_type
+    LEFT JOIN note_data ON (note_data.jsonb ->> 'typeId')::uuid = (note_type.id)
     GROUP BY note_type.id;

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -34,27 +34,27 @@
   "scripts": [
     {
       "run": "after",
-      "snippet": "ALTER TABLE note_data ADD COLUMN IF NOT EXISTS temporary_type_id UUID REFERENCES note_type (id);CREATE OR REPLACE FUNCTION update_type_id()RETURNS TRIGGER AS $$BEGIN  NEW.temporary_type_id = NEW.jsonb->>'typeId';  RETURN NEW;END;$$ language 'plpgsql'; DROP TRIGGER IF EXISTS update_type_id  ON note_data; CREATE TRIGGER update_type_id  BEFORE INSERT OR UPDATE ON note_data  FOR EACH ROW EXECUTE PROCEDURE update_type_id();",
+      "snippetPath": "check_type_id.sql",
       "fromModuleVersion": "1.0"
     },
     {
       "run": "after",
-      "snippet": "CREATE OR REPLACE VIEW note_view AS SELECT note_data.id, jsonb_build_object( 'id', note_data.jsonb->>'id',  'title', note_data.jsonb->>'title', 'domain', note_data.jsonb->>'domain', 'content', note_data.jsonb->>'content',  'creator', note_data.jsonb->'creator',  'updater', note_data.jsonb->'updater',  'links', note_data.jsonb->'links',  'linkTypes',  (SELECT array_agg(DISTINCT type) FROM jsonb_to_recordset(note_data.jsonb->'links') AS x(type text)),  'linkIds',  (SELECT array_agg(DISTINCT id) FROM jsonb_to_recordset(note_data.jsonb->'links') AS x(id text)), 'metadata', note_data.jsonb->'metadata',  'typeId', note_type.jsonb->'id', 'type', note_type.jsonb->'name') AS jsonb FROM note_data LEFT JOIN note_type ON note_data.jsonb->>'typeId' = note_type.jsonb->>'id';",
+      "snippetPath": "create_note_view.sql",
       "fromModuleVersion": "1.0"
     },
     {
       "run": "after",
-      "snippet": "CREATE OR REPLACE FUNCTION set_note_data_md_json()        RETURNS TRIGGER    AS $$     DECLARE        createdDate timestamp WITH TIME ZONE;        createdBy text ;        updatedDate timestamp WITH TIME ZONE;        updatedBy text ;        injectedMetadata text;        createdByUsername text;        updatedByUsername text;     BEGIN       createdBy = OLD.jsonb->'metadata'->>'createdByUserId';       createdDate = OLD.jsonb->'metadata'->>'createdDate';       createdByUsername = OLD.jsonb->'metadata'->>'createdByUsername';       updatedBy = NEW.jsonb->'metadata'->>'updatedByUserId';       updatedDate = NEW.jsonb->'metadata'->>'updatedDate';       updatedByUsername = NEW.jsonb->'metadata'->>'updatedByUsername';       if createdBy ISNULL then     createdBy = 'undefined';   end if;       if updatedBy ISNULL then     updatedBy = 'undefined';   end if;       if createdByUsername ISNULL then     createdByUsername = 'undefined';   end if;       if updatedByUsername ISNULL then     updatedByUsername = 'undefined';   end if;       if createdDate IS NOT NULL           then injectedMetadata = '{\"createdDate\":\"'||to_char(createdDate,'YYYY-MM-DD\"T\"HH24:MI:SS.MS')||'\" , \"createdByUserId\":\"'||createdBy||'\" , \"createdByUsername\":\"'||createdByUsername||'\", \"updatedDate\":\"'||to_char(updatedDate,'YYYY-MM-DD\"T\"HH24:MI:SS.MSOF')||'\" , \"updatedByUserId\":\"'||updatedBy||'\" , \"updatedByUsername\":\"'|| updatedByUsername||'\"}';           NEW.jsonb = jsonb_set(NEW.jsonb, '{metadata}' ,  injectedMetadata::jsonb , false);       else         NEW.jsonb = NEW.jsonb;       end if;     RETURN NEW;     END;    $$    language 'plpgsql';        DROP TRIGGER IF EXISTS set_note_data_md_json_trigger ON note_data CASCADE;        CREATE TRIGGER set_note_data_md_json_trigger BEFORE UPDATE ON note_data   FOR EACH ROW EXECUTE PROCEDURE set_note_data_md_json();        DROP TRIGGER IF EXISTS set_note_data_md_trigger ON note_data CASCADE;        DROP FUNCTION IF EXISTS note_data_set_md();        ALTER TABLE note_data DROP COLUMN IF EXISTS created_by, DROP COLUMN IF EXISTS creation_date;",
+      "snippetPath": "note_data_update_metadata_user_info.sql",
       "fromModuleVersion": "1.0"
     },
     {
       "run": "after",
-      "snippet": "CREATE OR REPLACE FUNCTION set_note_type_md_json()        RETURNS trigger    AS $$      DECLARE        createdDate timestamp WITH TIME ZONE;        createdBy text ;        updatedDate timestamp WITH TIME ZONE;        updatedBy text ;        injectedMetadata text;        createdByUsername text;        updatedByUsername text;      BEGIN        createdBy = OLD.jsonb->'metadata'->>'createdByUserId';        createdDate = OLD.jsonb->'metadata'->>'createdDate';        createdByUsername = OLD.jsonb->'metadata'->>'createdByUsername';        updatedBy = NEW.jsonb->'metadata'->>'updatedByUserId';        updatedDate = NEW.jsonb->'metadata'->>'updatedDate';        updatedByUsername = NEW.jsonb->'metadata'->>'updatedByUsername';        if createdBy ISNULL then     createdBy = 'undefined';   end if;        if updatedBy ISNULL then     updatedBy = 'undefined';   end if;        if createdByUsername ISNULL then     createdByUsername = 'undefined';   end if;        if updatedByUsername ISNULL then     updatedByUsername = 'undefined';   end if;        if createdDate IS NOT NULL            then injectedMetadata = '{\"createdDate\":\"'||to_char(createdDate,'YYYY-MM-DD\"T\"HH24:MI:SS.MS')||'\" , \"createdByUserId\":\"'||createdBy||'\" , \"createdByUsername\":\"'||createdByUsername||'\", \"updatedDate\":\"'||to_char(updatedDate,'YYYY-MM-DD\"T\"HH24:MI:SS.MSOF')||'\" , \"updatedByUserId\":\"'||updatedBy||'\" , \"updatedByUsername\":\"'|| updatedByUsername||'\"}';            NEW.jsonb = jsonb_set(NEW.jsonb, '{metadata}' ,  injectedMetadata::jsonb , false);        else          NEW.jsonb = NEW.jsonb;        end if;     RETURN NEW;     END;    $$    language 'plpgsql';        DROP TRIGGER IF EXISTS set_note_type_md_json_trigger ON note_type CASCADE;        CREATE TRIGGER set_note_type_md_json_trigger BEFORE UPDATE ON note_type   FOR EACH ROW EXECUTE PROCEDURE set_note_type_md_json();        DROP TRIGGER IF EXISTS set_note_type_md_trigger ON note_type CASCADE;        DROP FUNCTION IF EXISTS note_type_set_md();        ALTER TABLE note_type DROP COLUMN IF EXISTS created_by, DROP COLUMN IF EXISTS creation_date;",
+      "snippetPath": "note_type_update_metadata_user_info.sql",
       "fromModuleVersion": "1.0"
     },
     {
       "run": "after",
-      "snippet": "CREATE OR REPLACE VIEW note_type_view AS SELECT note_type.id, jsonb_build_object('id', note_type.jsonb ->> 'id'::text, 'name', note_type.jsonb ->> 'name'::text, 'usage',json_build_object('noteTotal', count(note_data.jsonb ->> 'id'::text)), 'metadata', note_type.jsonb -> 'metadata'::text) AS jsonb FROM note_type LEFT JOIN note_data ON (note_data.jsonb ->> 'typeId')::uuid = (note_type.id) GROUP BY note_type.id;",
+      "snippetPath": "create_note_type_view.sql",
       "fromModuleVersion": "1.0"
     }
   ]


### PR DESCRIPTION
## Purpose
Remove duplication in sql scripts 

## Approach
Use new "snippetPath" attribute from RMB 27.0.0

## Learning
According to release notes (https://github.com/folio-org/raml-module-builder/releases/tag/v26.0.0) the major change from 25.0.1 to 26.0.0 is related to changes in audit table, as far as I know mod-notes doesn't directly depend on this table, so this update should be safe, 

Breaking changes for upgrading to 27.0.0 (https://github.com/folio-org/raml-module-builder/releases/tag/v27.0.0) include 
* RMB-318 Database config: Drop deprecated dot (db.port) variables, use underscore (DB_PORT)
* RMB-445 rename HttpStatus.HTTP_VALIDATION_ERROR to HttpStatus.HTTP_UNPROCESSABLE_ENTITY for 422

Those changes should also be safe and not affect mod-notes

There's also an RMB upgrade guide, (https://github.com/folio-org/raml-module-builder/blob/v25.0.1/doc/upgrading.md), but it doesn't mention anything for versions 26 and 27