### PR TITLE
MODNOTES-121: Add UUID validation

### DIFF
--- a/ramls/types/notes/note.json
+++ b/ramls/types/notes/note.json
@@ -7,11 +7,13 @@
     "id": {
       "type": "string",
       "description": "Unique generated identifier for the note",
+      "pattern" : "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
       "example": "62d00c36-a94f-434d-9cd2-c7ea159303da"
     },
     "typeId": {
       "type": "string",
       "description": "Type id of note",
+      "pattern" : "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
       "example": "13d00c36-a94f-434d-9cd2-c7ea159303da"
     },
     "type": {

--- a/ramls/types/notetypes/noteTypeItem.json
+++ b/ramls/types/notetypes/noteTypeItem.json
@@ -8,7 +8,8 @@
   "properties": {
     "id": {
       "description": "A UUID identifying this note type",
-      "type": "string"
+      "type": "string",
+      "pattern" : "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
     },
     "name": {
       "description": "The unique name of this type",

--- a/src/test/java/org/folio/rest/impl/NotesTest.java
+++ b/src/test/java/org/folio/rest/impl/NotesTest.java
@@ -213,8 +213,8 @@ public class NotesTest extends NotesTestBase {
   @Test
   public void shouldReturn422WhenPostHasInvalidUUID() {
     String bad4 = NOTE_1.replaceAll("-1111-", "-2-");  // make bad UUID
-    final String response = postWithStatus(NOTES_PATH, bad4, SC_BAD_REQUEST, USER9).asString();
-    Assert.assertThat(response, containsString("invalid input syntax for type uuid"));
+    Errors errors = postWithStatus(NOTES_PATH, bad4, SC_UNPROCESSABLE_ENTITY, USER9).as(Errors.class);
+    assertEquals("id", errors.getErrors().get(0).getParameters().get(0).getKey());
   }
 
   @Test


### PR DESCRIPTION
## Purpose
Make error message for requests with invalid UUID values more readable

## Approach
Add UUID validation to schema so that returned error has the same format as in other folio APIs

The new message is 
```
{
  "errors": [
    {
      "message": "must match \"^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$\"",
      "type": "1",
      "code": "-1",
      "parameters": [
        {
          "key": "id",
          "value": "invalid_type_id"
        }
      ]
    }
  ]
}
```