### PR TITLE
publish container to ci kubernetes when release/snap build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,6 +5,7 @@ buildMvn {
   mvnDeploy = true
   publishAPI = true
   runLintRamlCop = true
+  doKubeDeploy = true
 
   doDocker = {
     buildJavaDocker {


### PR DESCRIPTION
## Purpose
Enables kubeDeploy step on buildMvn pipeline to deploy container to CI kubernetes cluster on release/snapshot builds for FOLIO-2256.