### PR TITLE
MODNOTES-130 - Unable to add notes to Agreements/eholdings apps witho…

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -24,7 +24,8 @@
         {
           "methods": ["POST"],
           "pathPattern": "/notes",
-          "permissionsRequired": ["notes.item.post", "notes.domain.all"]
+          "permissionsRequired": ["notes.item.post", "notes.domain.all"],
+          "modulePermissions": ["users.item.get"]
         },
         {
           "methods": ["GET"],
@@ -34,7 +35,8 @@
         {
           "methods": ["PUT"],
           "pathPattern": "/notes/{id}",
-          "permissionsRequired": ["notes.item.put", "notes.domain.all"]
+          "permissionsRequired": ["notes.item.put", "notes.domain.all"],
+          "modulePermissions": ["users.item.get"]
         },
         {
           "methods": ["DELETE"],


### PR DESCRIPTION
## Purpose
Fix for bug https://issues.folio.org/browse/MODNOTES-130

## Approach
* fixed authorization exception by edition module permissions

## Learning
- [More about autorization](https://github.com/folio-org/okapi/blob/master/doc/security.md#authorization)
- from the [okapi guide](https://github.com/folio-org/okapi/blob/master/doc/guide.md#example-4-complete-moduledescriptor)
> There is also a third field, "modulePermissions" with the value "config.lookup". This tells that our module has been granted this permission. Even if the user will not have such a permission, the module does, and is therefore allowed to do something like looking up the configuration settings.
this option fits our needs in case of saving/updating a note, so, just updated the ModuleDescriptor file