### PR TITLE
MODNOTES-140: Fix Maven ${} variable replacement in src/main/resources

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,14 +179,8 @@
   </dependencies>
 
   <build>
-    <resources>
-      <resource>
-        <directory>src/main/resources</directory>
-        <filtering>true</filtering>
-      </resource>
-    </resources>
-
     <plugins>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>


### PR DESCRIPTION
Remove unneccessary and dangerous variable replacement.
See https://issues.folio.org/browse/FOLIO-2548