### PR TITLE
MODNOTES-144 - Notes Accordion: Make Note type column heading sortable

### DIFF
--- a/ramls/link.raml
+++ b/ramls/link.raml
@@ -85,7 +85,7 @@ traits:
           orderBy:
             displayName: Field to order by
             type: string
-            description: Field by which notes are ordered. Possible values are status, title
+            description: Field by which notes are ordered. Possible values are status, title, noteType
             example: status
             required: false
             default: status

--- a/src/main/java/org/folio/links/NoteLinksConstants.java
+++ b/src/main/java/org/folio/links/NoteLinksConstants.java
@@ -45,6 +45,8 @@ class NoteLinksConstants {
 
   static final String ORDER_BY_LINKS_NUMBER = "ORDER BY json_array_length((data.jsonb->>'links')::json) %s ";
 
+  static final String ORDER_BY_NOTE_TYPE = "ORDER BY type.jsonb->>'name' %s ";
+
   static final String LIMIT_OFFSET = "LIMIT ? OFFSET ? ";
 
   private static final String JOIN_NOTE_TYPE_TABLE = "LEFT JOIN %s as type on (data.jsonb -> 'typeId' = type.jsonb -> 'id') ";

--- a/src/main/java/org/folio/links/NoteLinksRepositoryImpl.java
+++ b/src/main/java/org/folio/links/NoteLinksRepositoryImpl.java
@@ -11,6 +11,7 @@ import static org.folio.links.NoteLinksConstants.LIMIT_OFFSET;
 import static org.folio.links.NoteLinksConstants.NOTE_TABLE;
 import static org.folio.links.NoteLinksConstants.NOTE_TYPE_TABLE;
 import static org.folio.links.NoteLinksConstants.ORDER_BY_LINKS_NUMBER;
+import static org.folio.links.NoteLinksConstants.ORDER_BY_NOTE_TYPE;
 import static org.folio.links.NoteLinksConstants.ORDER_BY_STATUS_CLAUSE;
 import static org.folio.links.NoteLinksConstants.ORDER_BY_TITLE_CLAUSE;
 import static org.folio.links.NoteLinksConstants.REMOVE_LINKS;
@@ -306,6 +307,8 @@ public class NoteLinksRepositoryImpl implements NoteLinksRepository {
       parameters.addValue(jsonLink);
     } else if (orderBy == OrderBy.LINKSNUMBER) {
       query.append(String.format(ORDER_BY_LINKS_NUMBER, order.toString()));
+    } else if (orderBy == OrderBy.NOTETYPE) {
+      query.append(String.format(ORDER_BY_NOTE_TYPE, order.toString()));
     } else {
       query.append(String.format(ORDER_BY_TITLE_CLAUSE, order.toString()));
     }

--- a/src/main/java/org/folio/model/OrderBy.java
+++ b/src/main/java/org/folio/model/OrderBy.java
@@ -6,7 +6,7 @@ import org.apache.commons.lang3.EnumUtils;
 
 public enum OrderBy {
 
-  STATUS("status"), TITLE("title"), LINKSNUMBER("linksNumber");
+  STATUS("status"), TITLE("title"), LINKSNUMBER("linksNumber"), NOTETYPE("noteType");
 
   private String value;
 

--- a/src/test/java/org/folio/rest/impl/NoteLinksImplTest.java
+++ b/src/test/java/org/folio/rest/impl/NoteLinksImplTest.java
@@ -368,6 +368,57 @@ public class NoteLinksImplTest extends NotesTestBase {
   }
 
   @Test
+  public void shouldReturnListOfNotesSortedByNoteTypeAsc(){
+    Note firstNote = getNote().withTitle("ABC").withTypeId("2af21797-d25b-46dc-8427-1759d1db2057");
+    Note secondNote = getNote().withTitle("XWZ");
+    postNoteWithOk(Json.encode(firstNote), USER8);
+    postNoteWithOk(Json.encode(secondNote), USER8);
+    createLinks(firstNote.getId());
+    createLinks(secondNote.getId());
+
+    List<Note> notes = getWithOk("/note-links/domain/" + DOMAIN + "/type/" + PACKAGE_TYPE + "/id/" + PACKAGE_ID
+      + "?orderBy=noteType&order=asc")
+      .as(NoteCollection.class)
+      .getNotes();
+
+    assertEquals(2, notes.size());
+    assertEquals(firstNote.getTypeId(), notes.get(0).getTypeId());
+    assertEquals(secondNote.getTypeId(), notes.get(1).getTypeId());
+  }
+
+  @Test
+  public void shouldReturnListOfNotesSortedByNoteTypeDesc(){
+    Note firstNote = getNote().withTitle("ABC");
+    Note secondNote = getNote().withTitle("XWZ");
+    postNoteWithOk(Json.encode(firstNote), USER8);
+    postNoteWithOk(Json.encode(secondNote), USER8);
+    createLinks(firstNote.getId());
+    createLinks(secondNote.getId());
+
+    List<Note> notes = getWithOk("/note-links/domain/" + DOMAIN + "/type/" + PACKAGE_TYPE + "/id/" + PACKAGE_ID
+      + "?orderBy=noteType&order=desc")
+      .as(NoteCollection.class)
+      .getNotes();
+
+    assertEquals(2, notes.size());
+    assertEquals(secondNote.getTypeId(), notes.get(0).getTypeId());
+    assertEquals(firstNote.getTypeId(), notes.get(1).getTypeId());
+  }
+
+  @Test
+  public void shouldReturn400WhenOrderParameterIsInvalid() {
+    Note firsNoteWithAssignedLink = createNote();
+    createNote();
+    createLinks(firsNoteWithAssignedLink.getId());
+
+    final String response = getWithStatus("/note-links/domain/" + DOMAIN + "/type/" + PACKAGE_TYPE  + "/id/" + PACKAGE_ID
+      + "?orderBy=noteype&order=desc", 400)
+      .asString();
+
+    assertThat(response, containsString("OrderBy is incorrect: noteype. Possible values: status, title, linksNumber, noteType"));
+  }
+
+  @Test
   public void shouldReturnListOfNotesSearchedByTitle() {
     Note firstNote = getNote().withTitle("Title ABC");
     Note secondNote = getNote().withTitle("Title ZZZ ABC");


### PR DESCRIPTION
## Purpose
The story is referring to https://issues.folio.org/browse/MODNOTES-144 to add the ability to sort notes by note type

## Approach
* updated raml file with information about ordering by noteType
* updated existing implementation with ability to sort by noteType
* added tests

