### PR TITLE
MODNOTES-141 Extend Note title limit to 255 characters

### DIFF
--- a/ramls/types/notes/note.json
+++ b/ramls/types/notes/note.json
@@ -29,7 +29,7 @@
     },
     "title": {
       "type": "string",
-      "maxLength": 75,
+      "maxLength": 255,
       "description": "Note title",
       "example": "BU Campus only issues"
     },

--- a/src/test/resources/note/note5LongTitle.json
+++ b/src/test/resources/note/note5LongTitle.json
@@ -1,7 +1,7 @@
 {
   "id": "33333333-1111-1111-a333-333333333333",
   "typeId": "13f21797-d25b-46dc-8427-1759d1db2057",
-  "title": "Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo lig",
+  "title": "This line has more than 255 characters. Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque",
   "domain": "eholdings",
   "content": "Test on things",
   "links": [


### PR DESCRIPTION
## Purpose
Extend Note title limit to 255 characters

## Approach
* Update raml definition
* Update test data