### PR TITLE
MODNOTES-147 Make Note title and details column sortable

### DIFF
--- a/ramls/link.raml
+++ b/ramls/link.raml
@@ -85,8 +85,8 @@ traits:
         orderBy:
           displayName: Field to order by
           type: string
-          description: Field by which notes are ordered. Possible values are status, title, linksNumber, noteType, updatedDate.
-            The default ascending sorting is applied for status, title, linksNumber, noteType parameters.
+          description: Field by which notes are ordered. Possible values are status, title, content, linksNumber, noteType, updatedDate.
+            The default ascending sorting is applied for status, title, content, linksNumber, noteType parameters.
             For updatedDate is descending. Explicit selection of sorting can be set by using order query parameter.
           required: false
           default: status

--- a/src/main/java/org/folio/links/NoteLinksConstants.java
+++ b/src/main/java/org/folio/links/NoteLinksConstants.java
@@ -43,6 +43,8 @@ class NoteLinksConstants {
 
   static final String ORDER_BY_TITLE_CLAUSE = "ORDER BY data.jsonb->>'title' %s ";
 
+  static final String ORDER_BY_CONTENT_CLAUSE = "ORDER BY data.jsonb->>'title' || regexp_replace(data.jsonb->>'content', E'<[^>]+>', '', 'gi') %s ";
+
   static final String ORDER_BY_LINKS_NUMBER = "ORDER BY json_array_length((data.jsonb->>'links')::json) %s ";
 
   static final String ORDER_BY_NOTE_TYPE = "ORDER BY type.jsonb->>'name' %s ";

--- a/src/main/java/org/folio/links/NoteLinksRepositoryImpl.java
+++ b/src/main/java/org/folio/links/NoteLinksRepositoryImpl.java
@@ -10,6 +10,7 @@ import static org.folio.links.NoteLinksConstants.INSERT_LINKS;
 import static org.folio.links.NoteLinksConstants.LIMIT_OFFSET;
 import static org.folio.links.NoteLinksConstants.NOTE_TABLE;
 import static org.folio.links.NoteLinksConstants.NOTE_TYPE_TABLE;
+import static org.folio.links.NoteLinksConstants.ORDER_BY_CONTENT_CLAUSE;
 import static org.folio.links.NoteLinksConstants.ORDER_BY_LINKS_NUMBER;
 import static org.folio.links.NoteLinksConstants.ORDER_BY_NOTE_TYPE;
 import static org.folio.links.NoteLinksConstants.ORDER_BY_STATUS_CLAUSE;
@@ -312,6 +313,8 @@ public class NoteLinksRepositoryImpl implements NoteLinksRepository {
       query.append(String.format(ORDER_BY_NOTE_TYPE, getSort(order, Order.ASC)));
     } else if (orderBy == OrderBy.UPDATEDDATE) {
       query.append(String.format(ORDER_BY_UPDATED_DATE, getSort(order, Order.DESC)));
+    } else if (orderBy == OrderBy.CONTENT) {
+      query.append(String.format(ORDER_BY_CONTENT_CLAUSE, getSort(order, Order.ASC)));
     } else {
       query.append(String.format(ORDER_BY_TITLE_CLAUSE, getSort(order, Order.ASC)));
     }

--- a/src/main/java/org/folio/model/OrderBy.java
+++ b/src/main/java/org/folio/model/OrderBy.java
@@ -6,7 +6,12 @@ import org.apache.commons.lang3.EnumUtils;
 
 public enum OrderBy {
 
-  STATUS("status"), TITLE("title"), LINKSNUMBER("linksNumber"), NOTETYPE("noteType"), UPDATEDDATE("updatedDate");
+  STATUS("status"),
+  TITLE("title"),
+  CONTENT("content"),
+  LINKSNUMBER("linksNumber"),
+  NOTETYPE("noteType"),
+  UPDATEDDATE("updatedDate");
 
   private String value;
 

--- a/src/test/java/org/folio/rest/impl/NoteLinksImplTest.java
+++ b/src/test/java/org/folio/rest/impl/NoteLinksImplTest.java
@@ -415,7 +415,7 @@ public class NoteLinksImplTest extends NotesTestBase {
       + "?orderBy=noteype&order=desc", 400)
       .asString();
 
-    assertThat(response, containsString("OrderBy is incorrect: noteype. Possible values: status, title, linksNumber, noteType"));
+    assertThat(response, containsString("OrderBy is incorrect"));
   }
 
   @Test
@@ -538,7 +538,7 @@ public class NoteLinksImplTest extends NotesTestBase {
       + "?orderBy=u&order=desc", 400)
       .asString();
 
-    assertThat(response, containsString("OrderBy is incorrect: u. Possible values: status, title, linksNumber, noteType, updatedDate"));
+    assertThat(response, containsString("OrderBy is incorrect"));
   }
 
   @Test

--- a/src/test/java/org/folio/rest/impl/NoteLinksImplTest.java
+++ b/src/test/java/org/folio/rest/impl/NoteLinksImplTest.java
@@ -419,6 +419,78 @@ public class NoteLinksImplTest extends NotesTestBase {
   }
 
   @Test
+  public void shouldReturnListOfNotesSortedByContentAscWhenTitlesAreDifferent(){
+    Note firstNote = getNote().withTitle("ABC").withContent("<div> <strong>1</strong></div><h1>thing</h1>");
+    Note secondNote = getNote().withTitle("XWZ").withContent("<div> <strong>2</strong></div><h1>thing</h1>");
+    postNoteWithOk(Json.encode(firstNote), USER8);
+    postNoteWithOk(Json.encode(secondNote), USER8);
+    createLinks(firstNote.getId());
+    createLinks(secondNote.getId());
+
+    List<Note> notes = getWithOk("/note-links/domain/" + DOMAIN + "/type/" + PACKAGE_TYPE + "/id/" + PACKAGE_ID
+      + "?orderBy=content")
+      .as(NoteCollection.class)
+      .getNotes();
+
+    assertEquals(2, notes.size());
+    assertEquals(firstNote.getTitle(), notes.get(0).getTitle());
+  }
+
+  @Test
+  public void shouldReturnListOfNotesSortedByContentDescWhenTitlesAreDifferent(){
+    Note firstNote = getNote().withTitle("ABC").withContent("<div> <strong>1</strong></div><h1>thing</h1>");
+    Note secondNote = getNote().withTitle("XWZ").withContent("<div> <strong>2</strong></div><h1>thing</h1>");
+    postNoteWithOk(Json.encode(firstNote), USER8);
+    postNoteWithOk(Json.encode(secondNote), USER8);
+    createLinks(firstNote.getId());
+    createLinks(secondNote.getId());
+
+    List<Note> notes = getWithOk("/note-links/domain/" + DOMAIN + "/type/" + PACKAGE_TYPE + "/id/" + PACKAGE_ID
+      + "?orderBy=content&order=desc")
+      .as(NoteCollection.class)
+      .getNotes();
+
+    assertEquals(2, notes.size());
+    assertEquals(firstNote.getTitle(), notes.get(1).getTitle());
+  }
+
+  @Test
+  public void shouldReturnListOfNotesSortedByContentAscWhenTitlesAreSimilar(){
+    Note firstNote = getNote().withTitle("ABC").withContent("<div> <strong>1</strong></div><h1>thing</h1>");
+    Note secondNote = getNote().withTitle("ABC").withContent("<div> <strong>2</strong></div><h1>thing</h1>");
+    postNoteWithOk(Json.encode(firstNote), USER8);
+    postNoteWithOk(Json.encode(secondNote), USER8);
+    createLinks(firstNote.getId());
+    createLinks(secondNote.getId());
+
+    List<Note> notes = getWithOk("/note-links/domain/" + DOMAIN + "/type/" + PACKAGE_TYPE + "/id/" + PACKAGE_ID
+      + "?orderBy=content")
+      .as(NoteCollection.class)
+      .getNotes();
+
+    assertEquals(2, notes.size());
+    assertEquals(firstNote.getTitle(), notes.get(0).getTitle());
+  }
+
+  @Test
+  public void shouldReturnListOfNotesSortedByContentDescWhenTitlesAreSimilar(){
+    Note firstNote = getNote().withTitle("ABC").withContent("<div> <strong>1</strong></div><h1>thing</h1>");
+    Note secondNote = getNote().withTitle("ABC").withContent("<div> <strong>2</strong></div><h1>thing</h1>");
+    postNoteWithOk(Json.encode(firstNote), USER8);
+    postNoteWithOk(Json.encode(secondNote), USER8);
+    createLinks(firstNote.getId());
+    createLinks(secondNote.getId());
+
+    List<Note> notes = getWithOk("/note-links/domain/" + DOMAIN + "/type/" + PACKAGE_TYPE + "/id/" + PACKAGE_ID
+      + "?orderBy=content&order=desc")
+      .as(NoteCollection.class)
+      .getNotes();
+
+    assertEquals(2, notes.size());
+    assertEquals(firstNote.getTitle(), notes.get(1).getTitle());
+  }
+
+  @Test
   public void shouldReturnListOfNotesSortedByCreatedDateAsc(){
 
     Note firstNote = getNote().withTitle("ABC").withTypeId("2af21797-d25b-46dc-8427-1759d1db2057");


### PR DESCRIPTION
## Purpose
implementation story for https://issues.folio.org/browse/MODNOTES-147

## Approach
* updated raml file with information about ordering by content
* updated existing implementation with ability to sort by content
* added tests
