### PR TITLE
MODNOTES-165 Extend note schema to add additional properties 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,8 +14,8 @@
   </licenses>
 
   <properties>
-    <raml-module-builder.version>32.0.0-SNAPSHOT</raml-module-builder.version>
-    <folio-service-tools.version>1.6.1-SNAPSHOT</folio-service-tools.version>
+    <raml-module-builder.version>32.1.0</raml-module-builder.version>
+    <folio-service-tools.version>1.6.1</folio-service-tools.version>
     <folio-di-support.version>1.2.0</folio-di-support.version>
     <aspectj.version>1.9.6</aspectj.version>
     <spring.version>5.2.8.RELEASE</spring.version>

--- a/ramls/types/notes/note.json
+++ b/ramls/types/notes/note.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "description": "Notes about all kind of objects",
-  "additionalProperties": false,
+  "additionalProperties": true,
   "properties": {
     "id": {
       "type": "string",

--- a/src/main/java/org/folio/model/NoteView.java
+++ b/src/main/java/org/folio/model/NoteView.java
@@ -1,10 +1,15 @@
 package org.folio.model;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import javax.validation.constraints.NotNull;
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
@@ -15,7 +20,7 @@ import org.folio.rest.jaxrs.model.UserDisplayInfo;
 /**
  * Database representation of a note
  */
-@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonIgnoreProperties({"linkIds", "linkTypes"})
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class NoteView {
 
@@ -42,6 +47,9 @@ public class NoteView {
   private Metadata metadata;
 
   private List<Link> links = new ArrayList<>();
+
+  @JsonIgnore
+  private final Map<String, Object> additionalProperties = new HashMap<String, Object>();
 
   public String getId() {
     return id;
@@ -121,5 +129,20 @@ public class NoteView {
 
   public void setLinks(List<Link> links) {
     this.links = links;
+  }
+
+  @JsonAnyGetter
+  public Map<String, Object> getAdditionalProperties() {
+    return this.additionalProperties;
+  }
+
+  @JsonAnySetter
+  public void setAdditionalProperty(String name, Object value) {
+    this.additionalProperties.put(name, value);
+  }
+
+  public NoteView withAdditionalProperty(String name, Object value) {
+    this.additionalProperties.put(name, value);
+    return this;
   }
 }

--- a/src/main/resources/templates/db_scripts/create_note_view.sql
+++ b/src/main/resources/templates/db_scripts/create_note_view.sql
@@ -1,22 +1,15 @@
 -- Custom script to create note_view. Changes in this file will not result in an update of the view.
 -- To change the view, update this script and copy it to the appropriate scripts.snippet field of the schema.json
 CREATE OR REPLACE VIEW note_view AS
-  SELECT note_data.id,
-  jsonb_build_object(
-    'id', note_data.jsonb->>'id',
-    'title', note_data.jsonb->>'title',
-    'domain', note_data.jsonb->>'domain',
-    'content', note_data.jsonb->>'content',
-    'creator', note_data.jsonb->'creator',
-    'updater', note_data.jsonb->'updater',
-    'links', note_data.jsonb->'links',
-    'linkTypes',
-    (SELECT array_agg(DISTINCT type) FROM jsonb_to_recordset(note_data.jsonb->'links') AS x(type text)),
-    'linkIds',
-    (SELECT array_agg(DISTINCT id) FROM jsonb_to_recordset(note_data.jsonb->'links') AS x(id text)),
-    'metadata', note_data.jsonb->'metadata',
-    'typeId', note_type.jsonb->'id',
-    'type', note_type.jsonb->'name')
-  AS jsonb
-  FROM note_data
-    LEFT JOIN note_type ON note_data.jsonb->>'typeId' = note_type.jsonb->>'id';
+    SELECT nd.id,
+           nd.jsonb ||
+                jsonb_build_object(
+                   'linkTypes',
+                   (SELECT array_agg(DISTINCT type) FROM jsonb_to_recordset(nd.jsonb -> 'links') AS x(type text)),
+                   'linkIds',
+                   (SELECT array_agg(DISTINCT id) FROM jsonb_to_recordset(nd.jsonb -> 'links') AS x(id text)),
+                   'type',
+                   nt.jsonb -> 'name')
+           AS jsonb
+    FROM note_data nd
+     LEFT JOIN note_type nt ON nd.jsonb->>'typeId' = nt.jsonb->>'id';

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -40,7 +40,7 @@
     {
       "run": "after",
       "snippetPath": "create_note_view.sql",
-      "fromModuleVersion": "mod-notes-2.7.0"
+      "fromModuleVersion": "mod-notes-2.10.3"
     },
     {
       "run": "after",

--- a/src/test/java/org/folio/rest/impl/NotesTest.java
+++ b/src/test/java/org/folio/rest/impl/NotesTest.java
@@ -206,13 +206,6 @@ public class NotesTest extends NotesTestBase {
   }
 
   @Test
-  public void shouldReturn422WhenRequestHasUnrecognizedField() {
-    String badfieldDoc = NOTE_1.replaceFirst("type", "UnknownFieldName");
-    final String response = postWithStatus(NOTES_PATH, badfieldDoc, SC_UNPROCESSABLE_ENTITY, USER9).asString();
-    assertThat(response, containsString("Unrecognized field"));
-  }
-
-  @Test
   public void shouldReturn400WhenUserDoesntExist() {
     // Post by an unknown user 19, lookup fails
     postWithStatus(NOTES_PATH, NOTE_1, SC_BAD_REQUEST, USER19);

--- a/src/test/java/org/folio/rest/impl/NotesTest.java
+++ b/src/test/java/org/folio/rest/impl/NotesTest.java
@@ -10,6 +10,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.is;
@@ -41,8 +42,10 @@ import static org.folio.util.NoteTestData.USER8_ID;
 import static org.folio.util.NoteTestData.USER9;
 import static org.folio.util.NoteTestData.USER9_ID;
 
+import java.io.IOException;
 import java.util.Objects;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
 import com.github.tomakehurst.wiremock.matching.EqualToPattern;
 import com.github.tomakehurst.wiremock.matching.UrlPathPattern;
@@ -50,6 +53,7 @@ import io.restassured.RestAssured;
 import io.restassured.http.Header;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.After;
@@ -74,8 +78,6 @@ import org.folio.test.util.TokenTestUtil;
  * against the module - without any Okapi in the picture. Since we run with an
  * embedded postgres, we always start with an empty database, and can safely
  * leave test data in it.
- *
- * @author heikki
  */
 @RunWith(VertxUnitRunner.class)
 public class NotesTest extends NotesTestBase {
@@ -85,6 +87,9 @@ public class NotesTest extends NotesTestBase {
   // One that is not found in the mock data
   private static final String NOT_JSON = "This is not json";
   private static final String NOTES_PATH = "/notes";
+
+  private ObjectMapper mapper;
+
 
   @BeforeClass
   public static void setUpClass(TestContext context) {
@@ -100,6 +105,8 @@ public class NotesTest extends NotesTestBase {
 
   @Before
   public void setUp() throws Exception {
+     mapper = new ObjectMapper();
+
     stubFor(
       get(new UrlPathPattern(new EqualToPattern("/users/" + USER9_ID), false))
         .willReturn(new ResponseDefinitionBuilder()
@@ -598,8 +605,25 @@ public class NotesTest extends NotesTestBase {
     deleteWithNoContent(location);
   }
 
+  @Test
+  public void shouldSaveNoteWithArbitraryAttribute() throws IOException {
+    Note note = mapper.readValue(NOTE_1, Note.class);
+
+    String name = RandomStringUtils.randomAlphabetic(10);
+    String value = RandomStringUtils.randomAlphanumeric(32);
+    note.setAdditionalProperty(name, value);
+
+    postNoteWithOk(mapper.writeValueAsString(note), USER9);
+
+    final Note saved = getWithOk("/notes/11111111-1111-1111-a111-111111111111").as(Note.class);
+
+    assertThat(saved.getAdditionalProperties().size(), is(1));
+    assertThat(saved.getAdditionalProperties(), hasEntry(name, value));
+  }
+
   private void getNoteAndCheckContent(String query, String content) {
     final String response = getWithOk(NOTES_PATH + query).asString();
     assertThat(response, containsString(content));
   }
+
 }


### PR DESCRIPTION
## Purpose
Extend note schema to add additional properties. This is to support "popUpOnUser", "popUpOnCheckOut" attributes required by UI to show Note popup on User/Check-out pages.

## Approach
* update Note json schema to allow for additional properties
* modify note_view to include all potential additional properties
* update Note repository to handle additional properties