### PR TITLE
FOLIO-2913 Workflow api-lint, test dependent workflow 2

### DIFF
--- a/.github/workflows/test-depend.yml
+++ b/.github/workflows/test-depend.yml
@@ -1,0 +1,20 @@
+name: test-depend
+
+# STATUS: testing FOLIO-2913
+
+on:
+  workflow_run:
+    workflows: [ api-lint ]
+    types: [ completed ]
+    branches: [ folio-2913-depend-workflow ]
+
+jobs:
+  test-depend:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Verify depend
+      run: echo "This would only run if api-lint was completed."
+


### PR DESCRIPTION
It seems that both workflow files need to be available on the default branch.

(This is a DevOps testing task. Does not need review.)
