### PR TITLE
FOLIO-2898 Use new api-doc CI tool

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,11 +1,11 @@
 buildMvn {
   publishModDescriptor = true
   mvnDeploy = true
-  publishAPI = true
   doKubeDeploy = true
   buildNode =  'jenkins-agent-java11'
 
   doApiLint = true
+  doApiDoc = true
   apiTypes = 'RAML'
   apiDirectories = 'ramls'
 


### PR DESCRIPTION
See [FOLIO-2898](https://issues.folio.org/browse/FOLIO-2898) and https://dev.folio.org/guides/jenkinsfile/#back-end-modules
Use `doApiDoc` in Jenkinsfile. Replaces `publishAPI`.