### PR TITLE
MODNOTES-174 Add `class` attribute to whitelist

### DIFF
--- a/src/main/java/org/folio/spring/config/ApplicationConfig.java
+++ b/src/main/java/org/folio/spring/config/ApplicationConfig.java
@@ -103,7 +103,13 @@ public class ApplicationConfig {
   public Whitelist whitelist(@Value("#{${note.content.tags}}") String[] tags,
                              @Value("#{${note.content.attributes}}") Map<String, String[]> attributes) {
     Whitelist whitelist = new Whitelist().addTags(tags);
-    attributes.forEach(whitelist::addAttributes);
+    attributes.forEach((tag, attrs) -> {
+      // To make an attribute valid for all tags, use the pseudo tag :all, e.g. addAttributes(":all", "class").
+      if (tag.equals("all")) {
+        tag = ":" + tag;
+      }
+      whitelist.addAttributes(tag, attrs);
+    });
     return whitelist;
   }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,5 +3,5 @@ note.configuration.module=NOTES
 note.types.number.limit.default=25
 note.types.default.name=General note
 note.content.tags='p,strong,em,a,u,ol,ul,li,h1,h2,h3,br'
-note.content.attributes={a: 'href,rel,target'}
+note.content.attributes={all: 'class', a: 'href,rel,target'}
 

--- a/src/test/java/org/folio/note/HtmlSanitizerTest.java
+++ b/src/test/java/org/folio/note/HtmlSanitizerTest.java
@@ -19,7 +19,7 @@ public class HtmlSanitizerTest {
 
   @Test
   public void shouldNotSanitizeSupportedTags() {
-    String content = "<h1>a</h1><h2>b</h2><h3>c</h3><p>d</p><p><strong>e</strong></p><p><em>f</em></p><p><u>g</u></p><p><a href=\"https://examle.com\" rel=\"noopener noreferrer\" target=\"_blank\">h</a></p><ol><li>i</li></ol><ul><li>j</li></ul>";
+    String content = "<h1 class=\"A\">a</h1><h2>b</h2><h3>c</h3><p class=\"B\">d</p><p><strong>e</strong></p><p><em>f</em></p><p><u>g</u></p><p><a href=\"https://examle.com\" rel=\"noopener noreferrer\" target=\"_blank\">h</a></p><ol><li>i</li></ol><ul><li>j</li></ul>";
     String actual = sanitizer.sanitize(content);
 
     assertEquals(content, actual);


### PR DESCRIPTION
## Purpose
Allow saving HTML class attribute in note content

## Approach
Add `class` attribute to whitelist for all tags