### PR TITLE
MODNOTES-172 Error on COPY notes from Tab separated values (TSVs)

### DIFF
--- a/src/main/resources/templates/db_scripts/alter_update_search_content.sql
+++ b/src/main/resources/templates/db_scripts/alter_update_search_content.sql
@@ -1,0 +1,14 @@
+CREATE OR REPLACE FUNCTION update_search_content()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.search_content = ${myuniversity}_mod_notes.f_unaccent(coalesce(NEW.jsonb->>'title','') || ' '
+  || regexp_replace(
+      regexp_replace(
+          coalesce(NEW.jsonb->>'content',''),
+          E'<[^>]+>', '', 'gi'
+       ),
+      '\n+', ' ', 'gi'
+    ));
+  RETURN NEW;
+END;
+$$ language 'plpgsql';

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -59,6 +59,11 @@
       "run": "after",
       "snippetPath": "create_note_search_column.sql",
       "fromModuleVersion": "mod-notes-2.11.0"
+    },
+    {
+      "run": "after",
+      "snippetPath": "alter_update_search_content.sql",
+      "fromModuleVersion": "mod-notes-2.13.0"
     }
   ]
 }


### PR DESCRIPTION
## Purpose
Previously notes JSON data that are in TSVs were able to be imported directly into the database using the command
\copy ${TENANT}_mod_notes.note_data(id, jsonb) FROM 'notes.tsv' DELIMITER E'\t'
In the 2.10.3-SNAPSHOT version, an error is thrown when running this command:

{{ERROR: function f_unaccent(text) does not exist
LINE 1: SELECT f_unaccent(coalesce(NEW.jsonb->>'title','') || ' '
^

## Approach
Modify db function update_search_content()

## Learning
https://issues.folio.org/browse/MODNOTES-172
