### PR TITLE
MODNOTES-187 Rewrite tests for Notes

### DIFF
--- a/src/main/java/org/folio/notes/controller/NotesController.java
+++ b/src/main/java/org/folio/notes/controller/NotesController.java
@@ -1,12 +1,12 @@
 package org.folio.notes.controller;
 
+import java.net.URI;
 import java.util.List;
 import java.util.UUID;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import org.folio.notes.domain.dto.LinkStatusFilter;
 import org.folio.notes.domain.dto.Note;
@@ -26,12 +26,7 @@ public class NotesController implements NotesApi {
   @Override
   public ResponseEntity<Note> createNote(Note note) {
     var newNote = notesService.createNote(note);
-    var location = ServletUriComponentsBuilder
-      .fromCurrentRequest()
-      .path("/{id}")
-      .buildAndExpand(newNote.getId())
-      .toUri();
-    return ResponseEntity.created(location).body(newNote);
+    return ResponseEntity.created(URI.create("/notes/" + newNote.getId())).body(newNote);
   }
 
   @Override

--- a/src/test/java/org/folio/notes/controller/NoteControllerTest.java
+++ b/src/test/java/org/folio/notes/controller/NoteControllerTest.java
@@ -176,7 +176,7 @@ class NoteControllerTest extends TestApiBase {
       .andExpect(jsonPath("$.metadata.createdDate").isNotEmpty())
       .andExpect(header().string(HttpHeaders.LOCATION,
         matchesRegex(
-          "http://localhost" + NOTE_URL + "/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$")));
+          NOTE_URL + "/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$")));
     var rowsInTable = databaseHelper.countRowsInTable(TENANT, NOTE);
     assertEquals(1, rowsInTable);
   }

--- a/src/test/java/org/folio/notes/controller/NoteControllerTest.java
+++ b/src/test/java/org/folio/notes/controller/NoteControllerTest.java
@@ -1,0 +1,365 @@
+package org.folio.notes.controller;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.emptyOrNullString;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.matchesRegex;
+import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import javax.validation.ConstraintViolationException;
+
+import org.hamcrest.Matcher;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.web.servlet.ResultMatcher;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.testcontainers.shaded.org.apache.commons.lang.RandomStringUtils;
+
+import org.folio.notes.client.UsersClient;
+import org.folio.notes.domain.dto.Note;
+import org.folio.notes.domain.dto.NoteType;
+import org.folio.notes.domain.dto.User;
+import org.folio.notes.domain.entity.NoteEntity;
+import org.folio.notes.domain.entity.NoteTypeEntity;
+import org.folio.notes.exception.NoteNotFoundException;
+import org.folio.notes.support.TestApiBase;
+import org.folio.spring.cql.CqlQueryValidationException;
+
+class NoteControllerTest extends TestApiBase {
+
+  private static final String NOTE_URL = "/notes";
+  private static final String NOTE_TYPE_URL = "/note-types";
+  private static final String NOTE = "note";
+  private static final String DOMAIN = "domain";
+
+  @Value("${folio.notes.types.defaults.limit}")
+  private String defaultNoteTypeLimit;
+
+  @MockBean
+  private UsersClient client;
+
+  @BeforeEach
+  void setUp() {
+    var user = new User(UUID.randomUUID(), "test_user", null);
+    when(client.fetchUserById(USER_ID)).thenReturn(Optional.of(user));
+    setUpConfigurationLimit(defaultNoteTypeLimit);
+    databaseHelper.clearTable(TENANT);
+  }
+
+  // Tests for GET
+
+  @Test
+  @DisplayName("Find all notes - empty collection")
+  void returnEmptyCollection() throws Exception {
+    mockMvc.perform(get("/notes").headers(defaultHeaders()))
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$.notes").doesNotHaveJsonPath())
+      .andExpect(jsonPath("$.totalRecords").value(0));
+  }
+
+  @Test
+  @DisplayName("Find all notes")
+  void returnCollection() throws Exception {
+    List<NoteEntity> notes = createListOfNotes();
+
+    mockMvc.perform(get(NOTE_URL).headers(defaultHeaders()))
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$.notes.[0]", not(emptyOrNullString())))
+      .andExpect(jsonPath("$.notes.[1]", not(emptyOrNullString())))
+      .andExpect(jsonPath("$.notes.[0].title", is(notes.get(0).getTitle())))
+      .andExpect(jsonPath("$.notes.[1].title", is(notes.get(1).getTitle())))
+      .andExpect(jsonPath("$.totalRecords").value(notes.size()));
+  }
+
+  @Test
+  @DisplayName("Find all notes with sort by label and limited with offset")
+  void returnCollectionSortedByLabelAndLimitedWithOffset() throws Exception {
+    List<NoteEntity> notes = createListOfNotes();
+
+    var cqlQuery = "(cql.allRecords=1)sortby title/sort.descending";
+    var limit = "1";
+    var offset = "1";
+    mockMvc.perform(get(NOTE_URL + "?limit={l}&offset={o}&query={cql}", limit, offset, cqlQuery)
+        .headers(defaultHeaders()))
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$.notes.[0].title", is(notes.get(1).getTitle())))
+      .andExpect(jsonPath("$.notes.[1]").doesNotExist())
+      .andExpect(jsonPath("$.totalRecords").value(3));
+  }
+
+  @Test
+  @DisplayName("Find all notes by title")
+  void returnCollectionByName() throws Exception {
+    List<NoteEntity> notes = createListOfNotes();
+
+    var cqlQuery = "title=third";
+    mockMvc.perform(get(NOTE_URL + "?query={cql}", cqlQuery).headers(defaultHeaders()))
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$.notes.[0].title", is(notes.get(2).getTitle())))
+      .andExpect(jsonPath("$.notes.[1]").doesNotExist())
+      .andExpect(jsonPath("$.totalRecords").value(1));
+  }
+
+  @Test
+  @DisplayName("Return 422 on get collection with invalid CQL query")
+  void return422OnGetCollectionWithInvalidCqlQuery() throws Exception {
+    var cqlQuery = "!invalid-cql!";
+    mockMvc.perform(get(NOTE_URL + "?query={cql}", cqlQuery)
+        .headers(defaultHeaders()))
+      .andExpect(status().isUnprocessableEntity())
+      .andExpect(exceptionMatch(CqlQueryValidationException.class))
+      .andExpect(errorMessageMatch(containsString("Not implemented yet node type")));
+  }
+
+  @Test
+  @DisplayName("Return 422 on get collection with invalid offset")
+  void return422OnGetCollectionWithInvalidOffset() throws Exception {
+    mockMvc.perform(get(NOTE_URL + "?offset={offset}", -1)
+        .headers(defaultHeaders()))
+      .andExpect(status().isUnprocessableEntity())
+      .andExpect(exceptionMatch(ConstraintViolationException.class))
+      .andExpect(errorMessageMatch(containsString("must be greater than or equal to 0")));
+  }
+
+  @Test
+  @DisplayName("Return 422 on get collection with invalid limit")
+  void return422OnGetCollectionWithInvalidLimit() throws Exception {
+    mockMvc.perform(get(NOTE_URL + "?limit={limit}", -1)
+        .headers(defaultHeaders()))
+      .andExpect(status().isUnprocessableEntity())
+      .andExpect(exceptionMatch(ConstraintViolationException.class))
+      .andExpect(errorMessageMatch(containsString("must be greater than or equal to 1")));
+  }
+
+  // Tests for POST
+
+  @Test
+  @DisplayName("Create new note")
+  void createNewNote() throws Exception {
+    String title = "First";
+    var note = new Note().title(title);
+
+    var noteType = new NoteType().name(RandomStringUtils.randomAlphabetic(100));
+    var contentAsString = mockMvc.perform(postNoteType(noteType)).andReturn().getResponse().getContentAsString();
+    var existingNoteType = OBJECT_MAPPER.readValue(contentAsString, NoteType.class);
+
+    note.setDomain("Domain");
+    note.setTypeId(existingNoteType.getId());
+
+    mockMvc.perform(postNote(note))
+      .andExpect(status().isCreated())
+      .andExpect(jsonPath("$.title", is(title)))
+      .andExpect(jsonPath("$.metadata.createdByUserId").value(USER_ID))
+      .andExpect(jsonPath("$.metadata.createdDate").isNotEmpty())
+      .andExpect(header().string(HttpHeaders.LOCATION,
+        matchesRegex(
+          "http://localhost" + NOTE_URL + "/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$")));
+    var rowsInTable = databaseHelper.countRowsInTable(TENANT, NOTE);
+    assertEquals(1, rowsInTable);
+  }
+
+  @Test
+  @DisplayName("Return 422 on creation new note when note type is no created")
+  void return422onCreationNoteWhenNoteTypeIsNotCreated() throws Exception {
+    var note = new Note().title("First").domain("Domain");
+
+    mockMvc.perform(postNote(note))
+      .andExpect(status().isUnprocessableEntity())
+      .andExpect(exceptionMatch(MethodArgumentNotValidException.class))
+      .andExpect(errorMessageMatch(containsString("Field error in object 'note' on field 'typeId': rejected value [null]")));
+  }
+
+  @Test
+  @DisplayName("Return 422 on creation new note when domain is not set")
+  void return422onCreationNoteWhenDomainIsNotSet() throws Exception {
+    var note = new Note().title("First").typeId(UUID.randomUUID());
+
+    mockMvc.perform(postNote(note))
+      .andExpect(status().isUnprocessableEntity())
+      .andExpect(exceptionMatch(MethodArgumentNotValidException.class))
+      .andExpect(errorMessageMatch(containsString("Field error in object 'note' on field 'domain': rejected value [null]")));
+  }
+
+
+  // Tests for GET by id
+
+  @Test
+  @DisplayName("Find note by ID")
+  void returnById() throws Exception {
+    var note = createNote("NoteById");
+
+    mockMvc.perform(getById(note.getId()))
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$.id", is(note.getId().toString())))
+      .andExpect(jsonPath("$.title", is(note.getTitle())))
+      .andExpect(jsonPath("$.typeId", is(note.getType().getId().toString())))
+      .andExpect(jsonPath("$.metadata.createdDate").isNotEmpty());
+  }
+
+  @Test
+  @DisplayName("Return 404 on get note by ID when it is not exist")
+  void return404OnGetByIdWhenItNotExist() throws Exception {
+    mockMvc.perform(getById(UUID.randomUUID()))
+      .andExpect(status().isNotFound())
+      .andExpect(exceptionMatch(NoteNotFoundException.class))
+      .andExpect(errorMessageMatch(containsString("was not found")));
+  }
+
+  @Test
+  @DisplayName("Return 422 on get note by ID when id is invalid")
+  void return422OnGetByIdWhenIdIsInvalid() throws Exception {
+    mockMvc.perform(getById("invalid-uuid"))
+      .andExpect(status().isUnprocessableEntity())
+      .andExpect(exceptionMatch(MethodArgumentTypeMismatchException.class))
+      .andExpect(errorMessageMatch(containsString("Failed to convert value of type")));
+  }
+
+  // Tests for PUT
+
+  @Test
+  @DisplayName("Update existing note")
+  void updateExistingNoteType() throws Exception {
+    var existNote = createNote("Exist");
+
+    var updatedNote = new Note();
+    updatedNote.setTitle("Updated");
+    updatedNote.setDomain("Domain");
+    updatedNote.setTypeId(existNote.getType().getId());
+
+    mockMvc.perform(putById(existNote.getId(), updatedNote))
+      .andExpect(status().isNoContent());
+
+    mockMvc.perform(getById(existNote.getId()))
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$.id", is(existNote.getId().toString())))
+      .andExpect(jsonPath("$.title", is(updatedNote.getTitle())))
+      .andExpect(jsonPath("$.metadata.updatedByUserId").value(USER_ID))
+      .andExpect(jsonPath("$.metadata.createdDate").isNotEmpty());
+  }
+
+  @Test
+  @DisplayName("Return 404 on update note by ID when it is not exist")
+  void return404OnPutByIdWhenItNotExist() throws Exception {
+    var noteType = createNoteType();
+    var note = new Note().title("NotExist").domain("Domain").typeId(noteType.getId());
+
+    mockMvc.perform(putById(UUID.randomUUID(), note))
+      .andExpect(status().isNotFound())
+      .andExpect(exceptionMatch(NoteNotFoundException.class))
+      .andExpect(errorMessageMatch(containsString("was not found")));
+  }
+
+  // Tests for DELETE
+
+  @Test
+  @DisplayName("Delete existing note")
+  void deleteExistingNoteType() throws Exception {
+    var note = createNote("ToDelete");
+
+    mockMvc.perform(deleteById(note.getId()))
+      .andExpect(status().isNoContent());
+
+    var rowsInTable = databaseHelper.countRowsInTable(TENANT, NOTE);
+    assertEquals(0, rowsInTable);
+  }
+
+  @Test
+  @DisplayName("Return 404 on delete note by ID when it is not exist")
+  void return404OnDeleteByIdWhenItNotExist() throws Exception {
+    mockMvc.perform(deleteById(UUID.randomUUID()))
+      .andExpect(status().isNotFound())
+      .andExpect(exceptionMatch(NoteNotFoundException.class))
+      .andExpect(errorMessageMatch(containsString("was not found")));
+  }
+
+  private List<NoteEntity> createListOfNotes() {
+    List<NoteEntity> notes = List.of(
+      populateNote("first"),
+      populateNote("second"),
+      populateNote("third")
+    );
+    databaseHelper.saveNotes(notes, TENANT);
+    return notes;
+  }
+
+  private NoteEntity createNote(String title) {
+    var noteEntity = populateNote(title);
+    databaseHelper.saveNote(noteEntity, TENANT);
+    return noteEntity;
+  }
+
+  private NoteEntity populateNote(String title) {
+    var noteEntity = new NoteEntity();
+    noteEntity.setId(UUID.randomUUID());
+    noteEntity.setTitle(title);
+    noteEntity.setDomain(DOMAIN);
+    noteEntity.setType(createNoteType());
+    return noteEntity;
+  }
+
+  private NoteTypeEntity createNoteType() {
+    NoteTypeEntity noteType = new NoteTypeEntity();
+    noteType.setId(UUID.randomUUID());
+    noteType.setName(RandomStringUtils.randomAlphabetic(100));
+
+    databaseHelper.saveNoteType(noteType, TENANT);
+    return noteType;
+  }
+
+  private MockHttpServletRequestBuilder postNote(Note note) {
+    return post(NOTE_URL)
+      .headers(defaultHeaders())
+      .content(asJsonString(note));
+  }
+
+  private MockHttpServletRequestBuilder postNoteType(NoteType noteType) {
+    return post(NOTE_TYPE_URL)
+      .headers(defaultHeaders())
+      .content(asJsonString(noteType));
+  }
+
+  private MockHttpServletRequestBuilder getById(Object id) {
+    return get(NOTE_URL + "/{id}", id)
+      .headers(defaultHeaders());
+  }
+
+  private MockHttpServletRequestBuilder putById(UUID id, Note note) {
+    return put(NOTE_URL + "/{id}", id)
+      .content(asJsonString(note))
+      .headers(defaultHeaders());
+  }
+
+  private MockHttpServletRequestBuilder deleteById(UUID id) {
+    return delete(NOTE_URL + "/{id}", id)
+      .headers(defaultHeaders());
+  }
+
+  private ResultMatcher errorMessageMatch(Matcher<String> errorMessageMatcher) {
+    return jsonPath("$.errors.[0].message", errorMessageMatcher);
+  }
+
+  private <T> ResultMatcher exceptionMatch(Class<T> type) {
+    return result -> assertThat(result.getResolvedException(), instanceOf(type));
+  }
+}
+

--- a/src/test/java/org/folio/notes/controller/NoteControllerTest.java
+++ b/src/test/java/org/folio/notes/controller/NoteControllerTest.java
@@ -18,6 +18,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import static org.folio.notes.support.DatabaseHelper.NOTE;
+import static org.folio.notes.support.DatabaseHelper.TYPE;
 
 import java.util.List;
 import java.util.Optional;
@@ -65,6 +66,7 @@ class NoteControllerTest extends TestApiBase {
     when(client.fetchUserById(USER_ID)).thenReturn(Optional.of(user));
     setUpConfigurationLimit(defaultNoteTypeLimit);
     databaseHelper.clearTable(TENANT, NOTE);
+    databaseHelper.clearTable(TENANT, TYPE);
   }
 
   // Tests for GET

--- a/src/test/java/org/folio/notes/controller/NoteControllerTest.java
+++ b/src/test/java/org/folio/notes/controller/NoteControllerTest.java
@@ -17,6 +17,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import static org.folio.notes.support.DatabaseHelper.NOTE;
+
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -49,7 +51,6 @@ class NoteControllerTest extends TestApiBase {
 
   private static final String NOTE_URL = "/notes";
   private static final String NOTE_TYPE_URL = "/note-types";
-  private static final String NOTE = "note";
   private static final String DOMAIN = "domain";
 
   @Value("${folio.notes.types.defaults.limit}")
@@ -63,7 +64,7 @@ class NoteControllerTest extends TestApiBase {
     var user = new User(UUID.randomUUID(), "test_user", null);
     when(client.fetchUserById(USER_ID)).thenReturn(Optional.of(user));
     setUpConfigurationLimit(defaultNoteTypeLimit);
-    databaseHelper.clearTable(TENANT);
+    databaseHelper.clearTable(TENANT, NOTE);
   }
 
   // Tests for GET

--- a/src/test/java/org/folio/notes/controller/NoteTypesControllerTest.java
+++ b/src/test/java/org/folio/notes/controller/NoteTypesControllerTest.java
@@ -42,6 +42,7 @@ import org.folio.spring.cql.CqlQueryValidationException;
 class NoteTypesControllerTest extends TestApiBase {
 
   private static final String BASE_URL = "/note-types";
+  private static final String TYPE = "type";
 
   @Value("${folio.notes.types.defaults.limit}")
   private String defaultNoteTypeLimit;
@@ -154,7 +155,7 @@ class NoteTypesControllerTest extends TestApiBase {
         matchesRegex(
           BASE_URL + "/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$")));
 
-    int rowsInTable = databaseHelper.countRowsInTable(TENANT);
+    int rowsInTable = databaseHelper.countRowsInTable(TENANT, TYPE);
     assertEquals(1, rowsInTable);
   }
 
@@ -172,7 +173,7 @@ class NoteTypesControllerTest extends TestApiBase {
       .andExpect(jsonPath("$.metadata.createdByUserId").value(USER_ID))
       .andExpect(jsonPath("$.metadata.createdDate").isNotEmpty());
 
-    int rowsInTable = databaseHelper.countRowsInTable(TENANT);
+    int rowsInTable = databaseHelper.countRowsInTable(TENANT, TYPE);
     assertEquals(1, rowsInTable);
   }
 
@@ -204,7 +205,7 @@ class NoteTypesControllerTest extends TestApiBase {
       .andExpect(exceptionMatch(NoteTypesLimitReached.class))
       .andExpect(errorMessageMatch(containsString("Maximum number of note types allowed is " + limit)));
 
-    int rowsInTable = databaseHelper.countRowsInTable(TENANT);
+    int rowsInTable = databaseHelper.countRowsInTable(TENANT, TYPE);
     assertEquals(Integer.parseInt(limit), rowsInTable);
   }
 
@@ -293,7 +294,7 @@ class NoteTypesControllerTest extends TestApiBase {
     mockMvc.perform(deleteById(existNoteType.getId()))
       .andExpect(status().isNoContent());
 
-    var rowsInTable = databaseHelper.countRowsInTable(TENANT);
+    var rowsInTable = databaseHelper.countRowsInTable(TENANT, TYPE);
     assertEquals(0, rowsInTable);
   }
 

--- a/src/test/java/org/folio/notes/controller/NoteTypesControllerTest.java
+++ b/src/test/java/org/folio/notes/controller/NoteTypesControllerTest.java
@@ -16,6 +16,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import static org.folio.notes.support.DatabaseHelper.TYPE;
+
 import java.util.List;
 import java.util.UUID;
 
@@ -42,7 +44,6 @@ import org.folio.spring.cql.CqlQueryValidationException;
 class NoteTypesControllerTest extends TestApiBase {
 
   private static final String BASE_URL = "/note-types";
-  private static final String TYPE = "type";
 
   @Value("${folio.notes.types.defaults.limit}")
   private String defaultNoteTypeLimit;
@@ -50,7 +51,7 @@ class NoteTypesControllerTest extends TestApiBase {
   @BeforeEach
   void setUp() {
     setUpConfigurationLimit(defaultNoteTypeLimit);
-    databaseHelper.clearTable(TENANT);
+    databaseHelper.clearTable(TENANT, TYPE);
   }
 
   // Tests for GET

--- a/src/test/java/org/folio/notes/support/DatabaseHelper.java
+++ b/src/test/java/org/folio/notes/support/DatabaseHelper.java
@@ -6,11 +6,14 @@ import java.util.stream.Collectors;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.jdbc.JdbcTestUtils;
 
+import org.folio.notes.domain.entity.NoteEntity;
 import org.folio.notes.domain.entity.NoteTypeEntity;
 import org.folio.spring.FolioModuleMetadata;
 
 public class DatabaseHelper {
 
+  private static final String NOTE = "note";
+  private static final String TYPE = "type";
   private final FolioModuleMetadata metadata;
   private final JdbcTemplate jdbcTemplate;
 
@@ -19,27 +22,41 @@ public class DatabaseHelper {
     this.jdbcTemplate = jdbcTemplate;
   }
 
-  public int countRowsInTable(String tenant) {
-    return JdbcTestUtils.countRowsInTable(jdbcTemplate, getNoteTypeTable(tenant));
+  public int countRowsInTable(String tenant, String table) {
+    return JdbcTestUtils.countRowsInTable(jdbcTemplate, getTable(tenant, table));
   }
 
-  public String getNoteTypeTable(String tenantId) {
-    return metadata.getDBSchemaName(tenantId) + "." + "type";
+  public String getTable(String tenantId, String table) {
+    return metadata.getDBSchemaName(tenantId) + "." + table;
   }
 
   public void clearTable(String tenant) {
-    JdbcTestUtils.deleteFromTables(jdbcTemplate, getNoteTypeTable(tenant));
+    JdbcTestUtils.deleteFromTables(jdbcTemplate, getTable(tenant, TYPE));
+    JdbcTestUtils.deleteFromTables(jdbcTemplate, getTable(tenant, TYPE));
   }
 
   public void saveNoteType(NoteTypeEntity noteType, String tenant) {
-    var sql = "INSERT INTO " + getNoteTypeTable(tenant) + " (id, name) VALUES (?, ?)";
+    var sql = "INSERT INTO " + getTable(tenant, TYPE) + " (id, name) VALUES (?, ?)";
     jdbcTemplate.update(sql, noteType.getId(), noteType.getName());
   }
 
+  public void saveNote(NoteEntity note, String tenant) {
+    var sql = "INSERT INTO " + getTable(tenant, NOTE) + " (id, title, domain, type_id) VALUES (?,?,?,?)";
+    jdbcTemplate.update(sql, note.getId(), note.getTitle(), note.getDomain(), note.getType().getId());
+  }
+
   public void saveNoteTypes(List<NoteTypeEntity> noteTypes, String tenant) {
-    var sql = "INSERT INTO " + getNoteTypeTable(tenant) + " (name) VALUES (?)";
+    var sql = "INSERT INTO " + getTable(tenant, TYPE) + " (name) VALUES (?)";
     var args = noteTypes.stream()
       .map(noteType -> new Object[] {noteType.getName()})
+      .collect(Collectors.toList());
+    jdbcTemplate.batchUpdate(sql, args);
+  }
+
+  public void saveNotes(List<NoteEntity> noteTypes, String tenant) {
+    var sql = "INSERT INTO " + getTable(tenant, NOTE) + " (title, domain, type_id) VALUES (?,?,?)";
+    var args = noteTypes.stream()
+      .map(noteType -> new Object[] {noteType.getTitle(), noteType.getDomain(), noteType.getType().getId()})
       .collect(Collectors.toList());
     jdbcTemplate.batchUpdate(sql, args);
   }

--- a/src/test/java/org/folio/notes/support/DatabaseHelper.java
+++ b/src/test/java/org/folio/notes/support/DatabaseHelper.java
@@ -12,8 +12,8 @@ import org.folio.spring.FolioModuleMetadata;
 
 public class DatabaseHelper {
 
-  private static final String NOTE = "note";
-  private static final String TYPE = "type";
+  public static final String NOTE = "note";
+  public static final String TYPE = "type";
   private final FolioModuleMetadata metadata;
   private final JdbcTemplate jdbcTemplate;
 
@@ -30,9 +30,8 @@ public class DatabaseHelper {
     return metadata.getDBSchemaName(tenantId) + "." + table;
   }
 
-  public void clearTable(String tenant) {
-    JdbcTestUtils.deleteFromTables(jdbcTemplate, getTable(tenant, TYPE));
-    JdbcTestUtils.deleteFromTables(jdbcTemplate, getTable(tenant, TYPE));
+  public void clearTable(String tenant, String tableName) {
+    JdbcTestUtils.deleteFromTables(jdbcTemplate, getTable(tenant, tableName));
   }
 
   public void saveNoteType(NoteTypeEntity noteType, String tenant) {

--- a/src/test/java/org/folio/notes/support/TestApiBase.java
+++ b/src/test/java/org/folio/notes/support/TestApiBase.java
@@ -46,7 +46,7 @@ public abstract class TestApiBase extends TestBase {
   protected static final String TENANT = "test";
   protected static final String USER_ID = "77777777-7777-7777-7777-777777777777";
 
-  public static final ObjectMapper OBJECT_MAPPER;
+  protected static final ObjectMapper OBJECT_MAPPER;
 
   static {
     postgreDBContainer.start();

--- a/src/test/java/org/folio/notes/support/TestApiBase.java
+++ b/src/test/java/org/folio/notes/support/TestApiBase.java
@@ -10,6 +10,8 @@ import java.util.List;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -44,13 +46,15 @@ public abstract class TestApiBase extends TestBase {
   protected static final String TENANT = "test";
   protected static final String USER_ID = "77777777-7777-7777-7777-777777777777";
 
-  private static final ObjectMapper OBJECT_MAPPER;
+  public static final ObjectMapper OBJECT_MAPPER;
 
   static {
     postgreDBContainer.start();
     OBJECT_MAPPER = new ObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_NULL)
       .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-      .configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true);
+      .configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true)
+      .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
+    .registerModule(new JavaTimeModule());
   }
 
   @Autowired


### PR DESCRIPTION
## Purpose
To rewrite tests for Note Service by using spring

## Approach
- added tests for note service
- rewrite DatabaseHelper by adding common logic

#### TODOS and Open Questions
Discuss with team about **location** in the NotesController and NoteTypesController during creation entity. We have diffent behavior for creation location: 

- for note: http://localhost/notes/77777777-7777-7777-7777-777777777777 
- for note-type: /note-types/77777777-7777-7777-7777-777777777777

## Learning
https://issues.folio.org/browse/MODNOTES-187
