### PR TITLE
MODNOTES-192 Calculate note type usage and include it into responses

### DIFF
--- a/src/main/java/org/folio/notes/domain/repository/NoteTypeTuple.java
+++ b/src/main/java/org/folio/notes/domain/repository/NoteTypeTuple.java
@@ -1,0 +1,5 @@
+package org.folio.notes.domain.repository;
+
+public interface NoteTypeTuple {
+  String getNoteTypeId();
+}

--- a/src/main/java/org/folio/notes/domain/repository/NoteTypesRepository.java
+++ b/src/main/java/org/folio/notes/domain/repository/NoteTypesRepository.java
@@ -1,10 +1,17 @@
 package org.folio.notes.domain.repository;
 
+import java.util.List;
 import java.util.UUID;
+
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import org.folio.notes.domain.entity.NoteTypeEntity;
 import org.folio.spring.cql.JpaCqlRepository;
 
 public interface NoteTypesRepository extends JpaCqlRepository<NoteTypeEntity, UUID> {
 
+  @Query(value = "SELECT CAST(n.id AS varchar(50)) as noteId, CAST(n.type_id AS varchar(50)) as noteTypeId " +
+    "FROM note n WHERE n.type_id IN (:noteTypeIds)", nativeQuery = true)
+  List<NoteTypeTuple> findNoteUsage(@Param("noteTypeIds") List<UUID> noteTypeIds);
 }


### PR DESCRIPTION
## Purpose
Responses from GET endpoints of note-types API should include note type usage.

## Approach
- extend repository by adding search by count of notes

## Learning
https://issues.folio.org/browse/MODNOTES-192
