### PR TITLE
MODNOTES-194 Kiwi R3 2021 - Log4j vulnerability verification and correction

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 2.14.0-SNAPSHOT 2021-xx-xx
+* MODNOTES-194 Kiwi R3 2021 - Log4j vulnerability verification and correction
+
 ## 2.13.0 2021-10-04
 * MODNOTES-172 Add script to update function update_search_content()
 

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,13 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-bom</artifactId>
+        <version>2.16.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
## Purpose
Fix log4j2 `RCE` vulnerability

## Approach
- log4j2 version set to 2.16.0

## Learning
[MODNOTES-194](https://issues.folio.org/browse/MODNOTES-194)
[CVE-2021-44228](https://github.com/advisories/GHSA-jfh8-c2jp-5v3q)
[CVE-2021-45046](https://github.com/advisories/GHSA-7rjr-3q55-vv33)
`mvn dependency:tree -Dincludes=org.apache.logging.log4j` can be used to check log4j versions used
