### PR TITLE
MODNOTES-198 Spring way: rename module name to NOTES

### DIFF
--- a/src/main/java/org/folio/notes/service/impl/ConfigurationServiceImpl.java
+++ b/src/main/java/org/folio/notes/service/impl/ConfigurationServiceImpl.java
@@ -12,7 +12,7 @@ import org.folio.notes.service.ConfigurationService;
 @RequiredArgsConstructor
 public class ConfigurationServiceImpl implements ConfigurationService {
 
-  private static final String MODULE_NAME = "mod-notes";
+  private static final String MODULE_NAME = "NOTES";
   private static final String CONFIG_QUERY = "module==%s and configName==%s";
 
   private final ConfigurationClient client;

--- a/src/test/java/org/folio/notes/support/TestApiBase.java
+++ b/src/test/java/org/folio/notes/support/TestApiBase.java
@@ -100,13 +100,13 @@ public abstract class TestApiBase extends TestBase {
   protected void setUpConfigurationLimit(String limit) {
     List<ConfigurationEntry> configurations = new ArrayList<>();
     if (!limit.isBlank()) {
-      var configuration = new ConfigurationEntry("1", "mod-notes", "note-type-limit", limit);
+      var configuration = new ConfigurationEntry("1", "NOTES", "note-type-limit", limit);
       configurations.add(configuration);
     }
     var configs = new ConfigurationEntryCollection(configurations, configurations.size());
 
     Mockito.doReturn(configs).when(configurationClient)
-      .getConfiguration("module==mod-notes and configName==note-type-limit");
+      .getConfiguration("module==NOTES and configName==note-type-limit");
   }
 
   @TestConfiguration


### PR DESCRIPTION
## Purpose
Change module name to NOTES

## Approach
Change module name in tests and service

## Learning
https://issues.folio.org/browse/MODNOTES-198
