### PR TITLE
FOLIO-351 .editorconfig: Remove markdown exception

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,6 +9,3 @@ indent_size = 2
 indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
-
-[*.md]
-trim_trailing_whitespace = false


### PR DESCRIPTION
Use backslash line termination, rather than br or double-space
https://dev.folio.org/faqs/how-to-use-editorconfig/
