### PR TITLE
MODNOTES-204 Missing attributes in api response

### DIFF
--- a/src/main/java/org/folio/notes/domain/mapper/NoteCollectionMapper.java
+++ b/src/main/java/org/folio/notes/domain/mapper/NoteCollectionMapper.java
@@ -22,8 +22,6 @@ public interface NoteCollectionMapper {
   @Mapping(target = "metadata", source = ".", qualifiedByName = "BaseMetadataMapper")
   @Mapping(target = "typeId", expression = "java(entity.getType().getId())")
   @Mapping(target = "type", expression = "java(entity.getType().getName())")
-  @Mapping(target = "popUpOnCheckOut", ignore = true)
-  @Mapping(target = "popUpOnUser", ignore = true)
   Note toDto(NoteEntity entity);
 
   default NoteCollection toDtoCollection(Page<NoteEntity> entityList) {


### PR DESCRIPTION
## Purpose
Add  `popUpOnCheckOut`, `popUpOnUser` attributes in `/note-links` api response for users.

## Approach
- remove `ignore` for popUp attributes in mapper

## Learning
[MODNOTES-204](https://issues.folio.org/browse/MODNOTES-204)
