### PR TITLE
MODNOTES-206 Always return `notes` property on GET /notes

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -72,7 +72,7 @@ spring:
   autoconfigure:
     exclude: org.springframework.boot.autoconfigure.mustache.MustacheAutoConfiguration
   jackson:
-    default-property-inclusion: NON_EMPTY
+    default-property-inclusion: NON_NULL
   cache:
     type: caffeine
 management:

--- a/src/test/java/org/folio/notes/controller/NoteControllerTest.java
+++ b/src/test/java/org/folio/notes/controller/NoteControllerTest.java
@@ -106,7 +106,7 @@ class NoteControllerTest extends TestApiBase {
   void returnEmptyCollection() throws Exception {
     mockMvc.perform(get("/notes").headers(defaultHeaders()))
       .andExpect(status().isOk())
-      .andExpect(jsonPath("$.notes").doesNotHaveJsonPath())
+      .andExpect(jsonPath("$.notes").isEmpty())
       .andExpect(jsonPath("$.totalRecords").value(0));
   }
 

--- a/src/test/java/org/folio/notes/controller/NoteTypesControllerTest.java
+++ b/src/test/java/org/folio/notes/controller/NoteTypesControllerTest.java
@@ -75,7 +75,7 @@ class NoteTypesControllerTest extends TestApiBase {
   void returnEmptyCollection() throws Exception {
     mockMvc.perform(get("/note-types").headers(defaultHeaders()))
       .andExpect(status().isOk())
-      .andExpect(jsonPath("$.noteTypes").doesNotHaveJsonPath())
+      .andExpect(jsonPath("$.noteTypes").isEmpty())
       .andExpect(jsonPath("$.totalRecords").value(0));
   }
 

--- a/src/test/java/org/folio/notes/support/TestApiBase.java
+++ b/src/test/java/org/folio/notes/support/TestApiBase.java
@@ -54,6 +54,7 @@ public abstract class TestApiBase extends TestBase {
       .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
       .configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true)
       .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
+      .setSerializationInclusion(JsonInclude.Include.NON_NULL)
     .registerModule(new JavaTimeModule());
   }
 


### PR DESCRIPTION
## Purpose
Always return `notes` property on `GET /notes` even when there are no items in the property. This is dictated by the FOLIO convention.
