### PR TITLE
MODNOTES-219 Fix migration when userId is undefined

### DIFF
--- a/src/main/resources/db/changelog/changes/v3.0.0/migrate-data.xml
+++ b/src/main/resources/db/changelog/changes/v3.0.0/migrate-data.xml
@@ -5,7 +5,7 @@
   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
 
-  <changeSet id="MODNOTES-182@@migrate-note-types" author="Pavlo_Smahin">
+  <changeSet id="MODNOTES-182@@migrate-note-types" author="Pavlo_Smahin" runOnChange="true">
     <preConditions onFail="MARK_RAN">
       <tableExists tableName="note_type"/>
     </preConditions>

--- a/src/main/resources/db/changelog/changes/v3.0.0/sql/migrate-types.sql
+++ b/src/main/resources/db/changelog/changes/v3.0.0/sql/migrate-types.sql
@@ -1,8 +1,11 @@
 INSERT INTO type (id, name, created_by, created_date, updated_by, updated_date)
 SELECT id,
        jsonb->>'name',
-       (jsonb->'metadata'->>'createdByUserId')::uuid,
+       CASE WHEN (jsonb->'metadata'->>'createdByUserId')::text = 'undefined' THEN NULL
+       ELSE (jsonb->'metadata'->>'createdByUserId')::uuid END,
        to_timestamp(jsonb->'metadata'->>'createdDate', 'YYYY-MM-DDTHH24:MI:SS.MS'),
-       (jsonb->'metadata'->>'updatedByUserId')::uuid,
+       CASE WHEN (jsonb->'metadata'->>'updatedByUserId')::text = 'undefined' THEN NULL
+       ELSE (jsonb->'metadata'->>'updatedByUserId')::uuid END,
        to_timestamp(jsonb->'metadata'->>'updatedDate', 'YYYY-MM-DDTHH24:MI:SS.MS')
 FROM note_type
+ON CONFLICT DO NOTHING;

--- a/src/test/resources/migration/schema-v2-13-data.sql
+++ b/src/test/resources/migration/schema-v2-13-data.sql
@@ -18,7 +18,7 @@ INSERT INTO note_type(id, jsonb)
                                                  "metadata": {
                                                      "createdDate": "2021-10-28T10:46:55.066+00:00",
                                                      "updatedDate": "2021-10-28T10:46:55.066+00:00",
-                                                     "createdByUserId": "6f30f62c-d3cf-5ace-840d-6229ed676c4e",
+                                                     "createdByUserId": "undefined",
                                                      "updatedByUserId": "6f30f62c-d3cf-5ace-840d-6229ed676c4e",
                                                      "createdByUsername": "diku_admin"
                                                  }


### PR DESCRIPTION
## Purpose
Fix migration when userId is undefined

## Approach
Insert `null` if userId is `undefined` in previous data model