### PR TITLE
MODNOTES-244 - GET /notes type.id=X fails if limit <= number of results

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-    <folio-spring-base.version>4.1.0</folio-spring-base.version>
+    <folio-spring-base.version>4.2.0-SNAPSHOT</folio-spring-base.version>
     <mapstruct.version>1.5.1.Final</mapstruct.version>
     <jsoup.version>1.15.1</jsoup.version>
 

--- a/src/test/java/org/folio/notes/controller/NoteControllerTest.java
+++ b/src/test/java/org/folio/notes/controller/NoteControllerTest.java
@@ -135,6 +135,21 @@ class NoteControllerTest extends TestApiBase {
   }
 
   @Test
+  @DisplayName("Find all notes by type id and limit=totalRecords")
+  void returnCollectionByTypeIdAndLimitIsEqualToTotalRecords() throws Exception {
+    var note = createNote(TITLE_1);
+    var cqlQuery = "(type.id=" + note.getType().getId() + ")";
+    var limit = "1";
+    mockMvc.perform(get(NOTE_URL + "?limit={l}&query={cql}", limit, cqlQuery)
+        .headers(okapiHeaders()))
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$.notes.[0].title", is(note.getTitle())))
+      .andExpect(jsonPath("$.notes.[0].typeId", is(note.getType().getId().toString())))
+      .andExpect(jsonPath("$.notes.[1]").doesNotExist())
+      .andExpect(jsonPath("$.totalRecords").value(1));
+  }
+
+  @Test
   @DisplayName("Find all notes by title")
   void returnCollectionByName() throws Exception {
     List<NoteEntity> notes = createListOfNotes();

--- a/src/test/java/org/folio/notes/controller/NotesControllerTest.java
+++ b/src/test/java/org/folio/notes/controller/NotesControllerTest.java
@@ -170,7 +170,6 @@ class NotesControllerTest extends TestApiBase {
       .andExpect(jsonPath("$.totalRecords").value(1));
   }
 
-  @Test
   @MethodSource("cqlQueryProvider")
   @ParameterizedTest
   @DisplayName("Find only one note by CQL")


### PR DESCRIPTION
## Purpose
As described [MODNOTES-244](https://issues.folio.org/browse/MODNOTES-244), GET /notes type.id=X was failing if limit <= number of results

## Approach
The root cause is found and fixed in scope of [FOLSPRINGB-72](https://issues.folio.org/browse/FOLSPRINGB-72)

### Changes checklist
- [ ] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [ ] Interface versions changes
- [ ] Interface dependencies added, or removed
- [ ] Permissions changed, added, or removed

