### PR TITLE
MODNOTES-247 - Upgrade to folio-spring-base v5.0.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 ## 4.0.0-SNAPSHOT IN PROGRESS
 * MODNOTES-233 Do not include # of notes assigned to note types in response
+* MODNOTES-247 Upgrade to folio-spring-base v5.0.0
 
 ## 3.1.2 2022-08-08
 * Revert Nolana features (MODNOTES-233)
@@ -74,7 +75,7 @@
  * MODNOTES-127 - Update folio-service-tools with newer version
  * MODNOTES-117 - Remove dangerous html tags from note content
  * MODNOTES-119 - Fix error message for quering notes
- * MODNOTES-100 - Fix error message when we try to delete a note type 
+ * MODNOTES-100 - Fix error message when we try to delete a note type
 
 ## 2.6.1 2019-07-24
  * MODNOTES-115 - Ability to filter by notes types
@@ -104,7 +105,7 @@
  * MODNOTES-99 - Migrate the code to folio-service-tools library
  * MODNOTES-96 - Check note title and detail limit
  * MODNOTES-93 - Improvements: Modify metadata triggers not to use additional columns
- 
+
 ## 2.4.0 2019-05-08
  * MODNOTES-97 - Modify Module Descriptor, Dependencies and group id
  * MODNOTES-98 - Fix failing API Tests - missing validate annotation
@@ -113,8 +114,8 @@
  * MODNOTES-71 - Notes: Limit the number of note types that can be defined in the system
  * MODNOTES-88 - Note metadata fields are not completely stored on PUT
  * MODNOTES-69 - Notes: Support bulk method to add/remove notes from/to an entity
- * MODNOTES-66 - Notes: Support create new note 
- * MODNOTES-67 - Notes: Support note update 
+ * MODNOTES-66 - Notes: Support create new note
+ * MODNOTES-67 - Notes: Support note update
  * MODNOTES-65 - Notes: Support to GET note by id
  * MODNOTES-61 - Notes: Implement POST new type endpoint
  * MODNOTES-63 - Notes: Implement DELETE type endpoint

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.7.0</version>
+    <version>2.7.4</version>
     <relativePath /> <!-- lookup parent from repository -->
   </parent>
 
@@ -26,25 +26,25 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-    <folio-spring-base.version>4.2.0-SNAPSHOT</folio-spring-base.version>
-    <mapstruct.version>1.5.1.Final</mapstruct.version>
+    <folio-spring-base.version>5.0.0</folio-spring-base.version>
+    <mapstruct.version>1.5.2.Final</mapstruct.version>
     <jsoup.version>1.15.1</jsoup.version>
 
     <!-- Test properties -->
     <wiremock.version>2.27.2</wiremock.version>
-    <testcontainers.version>1.17.2</testcontainers.version>
+    <testcontainers.version>1.17.5</testcontainers.version>
 
     <!-- Plugin properties-->
     <openapi.input.file>${project.basedir}/src/main/resources/swagger.api/notes.yml</openapi.input.file>
-    <openapi-generator.version>5.4.0</openapi-generator.version>
+    <maven-openapi-generator.version>6.2.0</maven-openapi-generator.version>
     <copy-rename-maven-plugin.version>1.0.1</copy-rename-maven-plugin.version>
-    <versions-maven-plugin.version>2.11.0</versions-maven-plugin.version>
+    <versions-maven-plugin.version>2.12.0</versions-maven-plugin.version>
     <build-helper-maven-plugin.version>3.3.0</build-helper-maven-plugin.version>
     <maven-resources-plugin.version>3.2.0</maven-resources-plugin.version>
     <maven-surefire-plugin.version>3.0.0-M7</maven-surefire-plugin.version>
     <maven-release-plugin.version>3.0.0-M6</maven-release-plugin.version>
     <lombok.mapstruct-binding.version>0.2.0</lombok.mapstruct-binding.version>
-    <maven-checkstyle-plugin.version>3.1.1</maven-checkstyle-plugin.version>
+    <maven-checkstyle-plugin.version>3.1.2</maven-checkstyle-plugin.version>
   </properties>
 
   <dependencies>
@@ -282,7 +282,7 @@
       <plugin>
         <groupId>org.openapitools</groupId>
         <artifactId>openapi-generator-maven-plugin</artifactId>
-        <version>${openapi-generator.version}</version>
+        <version>${maven-openapi-generator.version}</version>
         <executions>
           <execution>
             <id>API generation</id>


### PR DESCRIPTION
## Purpose
Upgrade to folio-spring-base v5.0.0

### Changes checklist
- [ ] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [ ] Interface versions changes
- [ ] Interface dependencies added, or removed
- [ ] Permissions changed, added, or removed

### Learning
https://issues.folio.org/browse/MODNOTES-247
