### PR TITLE
MODNOTES-260: Spring Boot 3.0.5, upgrade Alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
 FROM folioci/alpine-jre-openjdk17:latest
 
+# Install latest patch versions of packages: https://pythonspeed.com/articles/security-updates-in-docker/
+USER root
+RUN apk upgrade --no-cache
+USER folio
+
 # Copy your fat jar to the container
 ENV APP_FILE mod-notes-fat.jar
 # - should be a single jar file

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.0.2</version>
+    <version>3.0.5</version>
     <relativePath /> <!-- lookup parent from repository -->
   </parent>
 


### PR DESCRIPTION
https://issues.folio.org/browse/MODNOTES-260

Upgrade spring-boot-starter-parent from 3.0.2 to 3.0.5.

Upgrade Alpine packages to the latest patch version.