### PR TITLE
MODNOTES-255 changed maximum records limit value.

### DIFF
--- a/src/main/java/org/folio/notes/service/impl/NotesServiceImpl.java
+++ b/src/main/java/org/folio/notes/service/impl/NotesServiceImpl.java
@@ -36,6 +36,7 @@ import org.folio.notes.exception.NoteNotFoundException;
 import org.folio.notes.service.NotesService;
 import org.folio.notes.util.HtmlSanitizer;
 import org.folio.spring.data.OffsetRequest;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Example;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Sort;
@@ -70,6 +71,9 @@ public class NotesServiceImpl implements NotesService {
         NotesOrderBy.UPDATEDDATE, AuditableEntity_.UPDATED_DATE
       );
   }
+
+  @Value("${folio.notes.response.limit}")
+  private Integer responseLimit;
 
   private final NoteRepository noteRepository;
   private final LinkRepository linkRepository;
@@ -114,10 +118,11 @@ public class NotesServiceImpl implements NotesService {
 
     log.debug("getNoteCollection:: trying to get Note collection by spec: {}, order: {}", spec, order);
     Sort sort = getSort(orderBy, order);
+    var actualLimit = Math.min(limit, responseLimit);
 
-    Page<NoteEntity> t = noteRepository.findAll(where(spec), OffsetRequest.of(offset, limit, sort));
+    Page<NoteEntity> t = noteRepository.findAll(where(spec), OffsetRequest.of(offset, actualLimit, sort));
     log.info("getNoteCollection:: loaded Note collection by spec: {}, offset: {}, limit: {}, sort: {}",
-      spec, offset, limit, sort);
+      spec, offset, actualLimit, sort);
     return noteCollectionMapper.toDtoCollection(t);
   }
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -46,6 +46,8 @@ folio:
             - href
             - rel
             - target
+    response:
+      limit: ${MAX_RECORDS_COUNT:1000}
 
 # Spring properties
 spring:

--- a/src/main/resources/swagger.api/notes.yml
+++ b/src/main/resources/swagger.api/notes.yml
@@ -199,7 +199,7 @@ paths:
       - $ref: '#/components/parameters/objectType'
       - $ref: '#/components/parameters/objectId'
     get:
-      description: Return a list of notes by status
+      description: Return a list of notes by status. A maximum of 1000 notes can be returned per request.
       operationId: getNoteCollectionByLink
       tags:
         - notes
@@ -379,6 +379,6 @@ components:
         type: integer
         default: 1000
         minimum: 1
-        maximum: 1000
+        maximum: 2147483647
       required: false
       description: Limit the number of elements returned in the response

--- a/src/main/resources/swagger.api/notes.yml
+++ b/src/main/resources/swagger.api/notes.yml
@@ -379,6 +379,6 @@ components:
         type: integer
         default: 1000
         minimum: 1
-        maximum: 2147483647
+        maximum: 1000
       required: false
       description: Limit the number of elements returned in the response

--- a/src/test/java/org/folio/notes/controller/NotesControllerTest.java
+++ b/src/test/java/org/folio/notes/controller/NotesControllerTest.java
@@ -971,6 +971,22 @@ class NotesControllerTest extends TestApiBase {
   }
 
   @Test
+  @DisplayName("should return list of notes with internal response limit")
+  void shouldReturnListOfNotesWithInternalResponseLimit() throws Exception {
+    generateNote();
+    generateNote();
+    generateNote();
+    generateNote();
+
+    var content = getNoteLinks("/note-links/domain/" + DOMAIN + "/type/" + PACKAGE_TYPE + "/id/" + PACKAGE_ID_1
+      + "?limit=100");
+    var notes = OBJECT_MAPPER.readValue(content, NoteCollection.class);
+
+    assertEquals(4, notes.getTotalRecords());
+    assertEquals(3, notes.getNotes().size());
+  }
+
+  @Test
   @DisplayName("Should return 400 with error message wrong order")
   void shouldReturn400WithErrorMessageWrongOrder() throws Exception {
     generateNote();

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -19,3 +19,5 @@ spring:
         format_sql: true
   autoconfigure:
     exclude: org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration,org.springframework.boot.autoconfigure.mustache.MustacheAutoConfiguration
+
+MAX_RECORDS_COUNT: 3


### PR DESCRIPTION
## Purpose
Changed the limit of the maximum number of records returned per request to reduce the risk of a recurrence of the problem with OutOfMemoryError.

## Approach
Set upped the limit of 1000 records.

### Changes checklist
- [ ] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [ ] Interface versions changes
- [ ] Interface dependencies added, or removed
- [ ] Permissions changed, added, or removed
- [ ] Check logging.
