### PR TITLE
build: update permissions for notes interface

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,16 @@
-## tbd
+## v6.0.0 In Progress
+### Breaking changes
+* Remove `notes.domain.all` permission
+* Rename `notes.collection.get.by.status` permission to `note.links.collection.get`
+
+### New APIs versions
+* Provides `notes v4.0`
+
 ### Dependencies
 * Fix scope of `folio-spring-testing` from default (compile) to test ([MODNOTES-268](https://folio-org.atlassian.net/browse/MODNOTES-268))
+
+### Tech Dept
+* Review and cleanup permissions ([MODNOTES-269](https://folio-org.atlassian.net/browse/MODNOTES-269))
 
 ## v5.2.0 2024-03-18
 ### Dependencies

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -14,7 +14,7 @@
   "provides": [
     {
       "id": "notes",
-      "version": "3.0",
+      "version": "4.0",
       "handlers": [
         {
           "methods": [
@@ -22,8 +22,7 @@
           ],
           "pathPattern": "/notes",
           "permissionsRequired": [
-            "notes.collection.get",
-            "notes.domain.all"
+            "notes.collection.get"
           ]
         },
         {
@@ -32,8 +31,7 @@
           ],
           "pathPattern": "/notes",
           "permissionsRequired": [
-            "notes.item.post",
-            "notes.domain.all"
+            "notes.item.post"
           ],
           "modulePermissions": [
             "users.item.get"
@@ -45,8 +43,7 @@
           ],
           "pathPattern": "/notes/{id}",
           "permissionsRequired": [
-            "notes.item.get",
-            "notes.domain.all"
+            "notes.item.get"
           ]
         },
         {
@@ -55,8 +52,7 @@
           ],
           "pathPattern": "/notes/{id}",
           "permissionsRequired": [
-            "notes.item.put",
-            "notes.domain.all"
+            "notes.item.put"
           ],
           "modulePermissions": [
             "users.item.get"
@@ -68,8 +64,7 @@
           ],
           "pathPattern": "/notes/{id}",
           "permissionsRequired": [
-            "notes.item.delete",
-            "notes.domain.all"
+            "notes.item.delete"
           ]
         },
         {
@@ -95,7 +90,9 @@
             "POST"
           ],
           "pathPattern": "/note-types",
-          "permissionsRequired": ["note.types.item.post"],
+          "permissionsRequired": [
+            "note.types.item.post"
+          ],
           "modulePermissions": [
             "configuration.entries.collection.get",
             "users.item.get"
@@ -106,8 +103,12 @@
             "PUT"
           ],
           "pathPattern": "/note-types/{id}",
-          "permissionsRequired": ["note.types.item.put"],
-          "modulePermissions": ["users.item.get"]
+          "permissionsRequired": [
+            "note.types.item.put"
+          ],
+          "modulePermissions": [
+            "users.item.get"
+          ]
         },
         {
           "methods": [
@@ -133,7 +134,7 @@
           ],
           "pathPattern": "/note-links/domain/{domain}/type/{type}/id/{id}",
           "permissionsRequired": [
-            "notes.collection.get.by.status"
+            "note.links.collection.get"
           ]
         }
       ]
@@ -186,11 +187,6 @@
       "description": "Delete note"
     },
     {
-      "permissionName": "notes.domain.all",
-      "displayName": "Notes - allow access to all domains",
-      "description": "All domains"
-    },
-    {
       "permissionName": "note.types.collection.get",
       "displayName": "Note types - get note types collection",
       "description": "Get note types collection"
@@ -221,9 +217,12 @@
       "description": "Update note links"
     },
     {
-      "permissionName": "notes.collection.get.by.status",
+      "permissionName": "note.links.collection.get",
       "displayName": "Notes - get notes collection sorted by status",
-      "description": "Get notes collection by status and domain"
+      "description": "Get notes collection by status and domain",
+      "replaces": [
+        "notes.collection.get.by.status"
+      ]
     },
     {
       "permissionName": "notes.allops",
@@ -236,7 +235,7 @@
         "notes.item.put",
         "notes.item.delete",
         "note.links.collection.put",
-        "notes.collection.get.by.status"
+        "note.links.collection.get"
       ],
       "visible": false
     },
@@ -259,7 +258,6 @@
       "description": "Entire set of permissions needed to use the notes modules on any domain",
       "subPermissions": [
         "notes.allops",
-        "notes.domain.all",
         "note.types.allops"
       ],
       "visible": false

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>org.folio</groupId>
   <artifactId>mod-notes</artifactId>
-  <version>5.3.0-SNAPSHOT</version>
+  <version>6.0.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <licenses>
@@ -33,6 +33,7 @@
 
     <!-- Plugin properties-->
     <openapi.input.file>${project.basedir}/src/main/resources/swagger.api/notes.yml</openapi.input.file>
+    <folio-module-descriptor-validator.version>1.0.0</folio-module-descriptor-validator.version>
     <maven-openapi-generator.version>7.8.0</maven-openapi-generator.version>
     <copy-rename-maven-plugin.version>1.0.1</copy-rename-maven-plugin.version>
     <versions-maven-plugin.version>2.17.1</versions-maven-plugin.version>
@@ -175,6 +176,19 @@
             </exclude>
           </excludes>
         </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.folio</groupId>
+        <artifactId>folio-module-descriptor-validator</artifactId>
+        <version>${folio-module-descriptor-validator.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>validate</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
 
       <plugin>


### PR DESCRIPTION
### Purpose
Review and cleanup Module Descriptors 

### Approach
Permissions of the notes interface changed:
notes.domain.all permissions deleted (it’s not required anymore)
notes.collection.get.by.status permission renamed to note.links.collection.get

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
https://folio-org.atlassian.net/browse/MODNOTES-269
